### PR TITLE
fix(ci): run tests separately in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,14 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Run tests
-        run: bun test
+      - name: Run unit tests
+        run: bun run test:unit
+
+      - name: Run integration tests
+        run: bun run test:integration
+
+      - name: Run E2E tests
+        run: bun run test:e2e
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Fix publish workflow test failures by running tests separately

## Changes

- Split `bun test` into separate test commands matching test.yml:
  - `bun run test:unit`
  - `bun run test:integration`
  - `bun run test:e2e`

## Root Cause

Running all tests together with `bun test` causes ESM compatibility issues with chalk v5 and execa in the bun test environment. Running tests separately avoids this conflict.

## Test Plan

- [x] Publish workflow passes all tests
- [ ] v0.2.0 release completes successfully