### PR TITLE
fix(security): add security headers and configuration to Next.js template

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,16 @@ Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## Security
 
+Generated applications include security headers by default:
+
+- **X-Content-Type-Options**: Prevents MIME type sniffing
+- **X-Frame-Options**: Prevents clickjacking attacks
+- **Referrer-Policy**: Controls referrer information sent with requests
+- **Permissions-Policy**: Restricts access to browser features
+- **Strict-Transport-Security**: Enforces HTTPS connections (HSTS)
+
+To customize security headers, edit `next.config.ts` in your web application.
+
 See [SECURITY.md](SECURITY.md) for vulnerability reporting.
 
 ## License

--- a/templates/base/web/next.config.ts
+++ b/templates/base/web/next.config.ts
@@ -1,7 +1,56 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Hide X-Powered-By header for security
+  poweredByHeader: false,
+
+  // Enable React strict mode for development
+  reactStrictMode: true,
+
+  // Configure allowed image sources
+  // NOTE: hostname "**" allows all domains - intentionally permissive for scaffolding.
+  // Users should restrict this in production to their specific CDN/image domains.
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
+
+  // Security headers
+  async headers() {
+    return [
+      {
+        // Apply to all routes (/:path* handles i18n correctly unlike /(.*))
+        source: "/:path*",
+        headers: [
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+          {
+            // HSTS - enforce HTTPS connections
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/tests/unit/template-security.test.ts
+++ b/tests/unit/template-security.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+describe("Security Configuration", () => {
+  const nextConfigPath = path.join(
+    process.cwd(),
+    "templates/base/web/next.config.ts"
+  );
+
+  it("should have next.config.ts with security settings", () => {
+    const content = fs.readFileSync(nextConfigPath, "utf-8");
+
+    // Check for poweredByHeader
+    expect(content).toContain("poweredByHeader: false");
+
+    // Check for reactStrictMode
+    expect(content).toContain("reactStrictMode: true");
+
+    // Check for security headers function
+    expect(content).toContain("async headers()");
+
+    // Check for required headers
+    expect(content).toContain("X-Content-Type-Options");
+    expect(content).toContain("X-Frame-Options");
+    expect(content).toContain("Referrer-Policy");
+    expect(content).toContain("Strict-Transport-Security");
+  });
+
+  it("should set X-Frame-Options to DENY", () => {
+    const content = fs.readFileSync(nextConfigPath, "utf-8");
+    expect(content).toContain('"DENY"');
+  });
+
+  it("should set X-Content-Type-Options to nosniff", () => {
+    const content = fs.readFileSync(nextConfigPath, "utf-8");
+    expect(content).toContain('"nosniff"');
+  });
+
+  it("should set HSTS with secure defaults", () => {
+    const content = fs.readFileSync(nextConfigPath, "utf-8");
+    expect(content).toContain("Strict-Transport-Security");
+    expect(content).toContain("max-age=31536000");
+    expect(content).toContain("includeSubDomains");
+  });
+
+  it("should NOT include deprecated X-XSS-Protection header", () => {
+    const content = fs.readFileSync(nextConfigPath, "utf-8");
+    expect(content).not.toContain("X-XSS-Protection");
+  });
+
+  it('should use /:path* pattern for i18n compatibility', () => {
+    const content = fs.readFileSync(nextConfigPath, "utf-8");
+    // /:path* handles i18n correctly, unlike /(.*)
+    expect(content).toContain('source: "/:path*"');
+  });
+});


### PR DESCRIPTION
## Summary

- Add security headers to Next.js template to protect against common web vulnerabilities
- Configure `next.config.ts` with security best practices
- Add unit tests to verify security configuration

## Changes

### Next.js Configuration (`templates/base/web/next.config.ts`)
- `poweredByHeader: false` - Hide X-Powered-By header that reveals Next.js
- `reactStrictMode: true` - Enable React strict mode for development safety
- `images.remotePatterns` - Configure allowed image sources (permissive for scaffolding)

### Security Headers
| Header | Value | Purpose |
|--------|-------|---------|
| X-Content-Type-Options | nosniff | Prevents MIME type sniffing |
| X-Frame-Options | DENY | Prevents clickjacking |
| Referrer-Policy | strict-origin-when-cross-origin | Controls referrer information |
| Permissions-Policy | camera=(), microphone=(), geolocation=() | Restricts browser features |
| Strict-Transport-Security | max-age=31536000; includeSubDomains | Enforces HTTPS (HSTS) |

### Tests
- Added `tests/unit/template-security.test.ts` with 6 tests verifying security configuration

### Documentation
- Updated README.md with security headers documentation

Closes #25