### PR TITLE
fix(cli): improve UX for platform selection and conditional prompts

### DIFF
--- a/src/prompts/features.ts
+++ b/src/prompts/features.ts
@@ -13,35 +13,50 @@ export interface AuthenticationConfig {
   twoFactor: boolean;
 }
 
-export async function promptFeatures(): Promise<any> {
+export async function promptFeatures(platforms: string[] = ['mobile', 'web']): Promise<any> {
+  const hasMobile = platforms.includes('mobile');
+
+  // Build choices based on platform
+  const choices = [];
+
+  // Only show onboarding for mobile
+  if (hasMobile) {
+    choices.push({
+      name: 'Onboarding Flow - Multi-step user onboarding (mobile only)',
+      value: 'onboarding',
+      checked: true,
+    });
+  }
+
+  // Authentication always available
+  choices.push({
+    name: 'Authentication - User authentication with BetterAuth',
+    value: 'authentication',
+    checked: true,
+  });
+
+  // Only show paywall for mobile
+  if (hasMobile) {
+    choices.push({
+      name: 'Subscription Paywall - RevenueCat integration (mobile only)',
+      value: 'paywall',
+      checked: false,
+    });
+  }
+
+  choices.push({
+    name: 'Session Management - Anonymous device session tracking',
+    value: 'sessionManagement',
+    checked: true,
+  });
+
   // First, ask about basic features
   const basicFeatures = await inquirer.prompt([
     {
       type: 'checkbox',
       name: 'features',
       message: 'Select features to include:',
-      choices: [
-        {
-          name: 'Onboarding Flow - Multi-step user onboarding',
-          value: 'onboarding',
-          checked: true,
-        },
-        {
-          name: 'Authentication - User authentication with BetterAuth',
-          value: 'authentication',
-          checked: true,
-        },
-        {
-          name: 'Subscription Paywall - RevenueCat integration',
-          value: 'paywall',
-          checked: false,
-        },
-        {
-          name: 'Session Management - Anonymous device session tracking',
-          value: 'sessionManagement',
-          checked: true,
-        },
-      ],
+      choices,
     },
   ]);
 
@@ -102,13 +117,13 @@ export async function promptFeatures(): Promise<any> {
 
   return {
     onboarding: {
-      enabled: basicFeatures.features.includes('onboarding'),
+      enabled: hasMobile ? basicFeatures.features.includes('onboarding') : false,
       pages: 3, // Will be configured later if enabled
       skipButton: false,
       showPaywall: false,
     },
     authentication: authConfig,
-    paywall: basicFeatures.features.includes('paywall'),
+    paywall: hasMobile ? basicFeatures.features.includes('paywall') : false,
     sessionManagement: basicFeatures.features.includes('sessionManagement'),
   };
 }

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -68,17 +68,21 @@ async function collectCustomConfiguration(): Promise<
   // Platform selection FIRST (foundational choice)
   const platforms = await promptPlatforms();
 
+  const hasMobile = platforms.includes('mobile');
+
   // ORM selection (foundational choice)
   const orm = await promptORM();
 
-  // Collect features
-  const features = await promptFeatures();
+  // Collect features (with platform awareness)
+  const features = await promptFeatures(platforms);
 
-  // Collect SDK integrations
-  const integrations = await promptSDKs();
+  // Collect SDK integrations only for mobile
+  const integrations = hasMobile
+    ? await promptSDKs()
+    : getDefaultIntegrations();
 
-  // If onboarding enabled, collect onboarding config
-  if (features.onboarding.enabled) {
+  // If onboarding enabled AND mobile platform, collect onboarding config
+  if (features.onboarding.enabled && hasMobile) {
     const onboardingConfig = await promptOnboarding(integrations.revenueCat.enabled);
     features.onboarding = { ...features.onboarding, ...onboardingConfig };
   }
@@ -100,6 +104,31 @@ async function collectCustomConfiguration(): Promise<
     },
     preset: 'custom',
     customized: false,
+  };
+}
+
+/**
+ * Returns default (disabled) integrations for web-only projects.
+ */
+function getDefaultIntegrations() {
+  return {
+    revenueCat: {
+      enabled: false,
+      iosKey: '',
+      androidKey: '',
+    },
+    adjust: {
+      enabled: false,
+      appToken: '',
+      environment: 'sandbox' as const,
+    },
+    scate: {
+      enabled: false,
+      apiKey: '',
+    },
+    att: {
+      enabled: false,
+    },
   };
 }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -80,7 +80,56 @@ export function validateConfiguration(config: ProjectConfig): ValidationResult {
     };
   }
 
-  // Validate paywall requires RevenueCat
+  // Validate mobile-only features on web-only config
+  // IMPORTANT: Check platform constraints BEFORE dependency constraints
+  // so users see the more fundamental error first
+  const hasMobile = config.platforms.includes('mobile');
+
+  if (!hasMobile) {
+    if (config.features.onboarding.enabled) {
+      return {
+        valid: false,
+        error: 'Onboarding feature requires mobile platform',
+      };
+    }
+
+    if (config.features.paywall) {
+      return {
+        valid: false,
+        error: 'Paywall feature requires mobile platform',
+      };
+    }
+
+    if (config.integrations.revenueCat.enabled) {
+      return {
+        valid: false,
+        error: 'RevenueCat integration requires mobile platform',
+      };
+    }
+
+    if (config.integrations.adjust.enabled) {
+      return {
+        valid: false,
+        error: 'Adjust integration requires mobile platform',
+      };
+    }
+
+    if (config.integrations.scate.enabled) {
+      return {
+        valid: false,
+        error: 'Scate integration requires mobile platform',
+      };
+    }
+
+    if (config.integrations.att.enabled) {
+      return {
+        valid: false,
+        error: 'ATT integration requires mobile platform',
+      };
+    }
+  }
+
+  // Validate paywall requires RevenueCat (only relevant when mobile platform is included)
   if (config.features.paywall && !config.integrations.revenueCat.enabled) {
     return {
       valid: false,

--- a/tests/integration/full-flow.test.ts
+++ b/tests/integration/full-flow.test.ts
@@ -121,8 +121,9 @@ describe('Integration Tests - Prompt Flows', () => {
       inquirer.prompt
         .mockResolvedValueOnce({ preset: 'Minimal' }) // Select preset
         .mockResolvedValueOnce({ customize: true }) // Customize
+        .mockResolvedValueOnce({ platformsToInclude: ['mobile', 'web'] }) // Platform selection
         .mockResolvedValueOnce({
-          // Customization answers
+          // Customization answers (mobile-only features + OAuth)
           onboarding: true,
           onboardingPages: 4,
           paywall: true,

--- a/tests/integration/preset-edge-cases.test.ts
+++ b/tests/integration/preset-edge-cases.test.ts
@@ -37,6 +37,7 @@ describe('Preset Edge Cases', () => {
 
   describe('customizePreset validation', () => {
     const mockConfig: Omit<ProjectConfig, 'projectName' | 'packageManager' | 'appScheme'> = {
+      platforms: ['mobile', 'web'],
       features: {
         onboarding: { enabled: true, pages: 3, skipButton: true, showPaywall: false },
         authentication: {
@@ -62,6 +63,7 @@ describe('Preset Edge Cases', () => {
       },
       backend: {
         database: 'postgresql',
+        orm: 'prisma',
         eventQueue: false,
         docker: true,
       },
@@ -73,6 +75,7 @@ describe('Preset Edge Cases', () => {
       // Mock user choosing to customize
       inquirer.prompt
         .mockResolvedValueOnce({ customize: true })
+        .mockResolvedValueOnce({ platformsToInclude: ['mobile', 'web'] }) // Platform selection
         .mockResolvedValueOnce({
           onboarding: true,
           onboardingPages: 0, // Invalid: too low
@@ -90,9 +93,9 @@ describe('Preset Edge Cases', () => {
 
       // Get the validate function from the onboardingPages question
       const promptCalls = inquirer.prompt.mock.calls;
-      const secondCall = promptCalls[1];
-      if (secondCall && secondCall[0]) {
-        const onboardingPagesQuestion = secondCall[0].find(
+      const thirdCall = promptCalls[2]; // Now the third call (after customize and platforms)
+      if (thirdCall && thirdCall[0]) {
+        const onboardingPagesQuestion = thirdCall[0].find(
           (q: any) => q.name === 'onboardingPages'
         );
         if (onboardingPagesQuestion && onboardingPagesQuestion.validate) {
@@ -107,6 +110,7 @@ describe('Preset Edge Cases', () => {
     it('should validate onboarding pages range (too high)', async () => {
       inquirer.prompt
         .mockResolvedValueOnce({ customize: true })
+        .mockResolvedValueOnce({ platformsToInclude: ['mobile', 'web'] }) // Platform selection
         .mockResolvedValueOnce({
           onboarding: true,
           onboardingPages: 6, // Invalid: too high
@@ -120,9 +124,9 @@ describe('Preset Edge Cases', () => {
       await new Promise(resolve => setTimeout(resolve, 10));
 
       const promptCalls = inquirer.prompt.mock.calls;
-      const secondCall = promptCalls[1];
-      if (secondCall && secondCall[0]) {
-        const onboardingPagesQuestion = secondCall[0].find(
+      const thirdCall = promptCalls[2]; // Now the third call (after customize and platforms)
+      if (thirdCall && thirdCall[0]) {
+        const onboardingPagesQuestion = thirdCall[0].find(
           (q: any) => q.name === 'onboardingPages'
         );
         if (onboardingPagesQuestion && onboardingPagesQuestion.validate) {
@@ -137,6 +141,7 @@ describe('Preset Edge Cases', () => {
     it('should accept valid onboarding pages', async () => {
       inquirer.prompt
         .mockResolvedValueOnce({ customize: true })
+        .mockResolvedValueOnce({ platformsToInclude: ['mobile', 'web'] }) // Platform selection
         .mockResolvedValueOnce({
           onboarding: true,
           onboardingPages: 3,
@@ -150,9 +155,9 @@ describe('Preset Edge Cases', () => {
       await new Promise(resolve => setTimeout(resolve, 10));
 
       const promptCalls = inquirer.prompt.mock.calls;
-      const secondCall = promptCalls[1];
-      if (secondCall && secondCall[0]) {
-        const onboardingPagesQuestion = secondCall[0].find(
+      const thirdCall = promptCalls[2]; // Now the third call (after customize and platforms)
+      if (thirdCall && thirdCall[0]) {
+        const onboardingPagesQuestion = thirdCall[0].find(
           (q: any) => q.name === 'onboardingPages'
         );
         if (onboardingPagesQuestion && onboardingPagesQuestion.validate) {

--- a/tests/unit/prompts-conditional.test.ts
+++ b/tests/unit/prompts-conditional.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock inquirer before importing modules that use it
+vi.mock('inquirer', () => ({
+  default: {
+    prompt: vi.fn(),
+  },
+}));
+
+// Mock all prompt modules
+vi.mock('../../src/prompts/platform.js', () => ({
+  promptPlatforms: vi.fn(),
+}));
+
+vi.mock('../../src/prompts/orm.js', () => ({
+  promptORM: vi.fn(),
+}));
+
+vi.mock('../../src/prompts/features.js', () => ({
+  promptFeatures: vi.fn(),
+}));
+
+vi.mock('../../src/prompts/sdks.js', () => ({
+  promptSDKs: vi.fn(),
+}));
+
+vi.mock('../../src/prompts/onboarding.js', () => ({
+  promptOnboarding: vi.fn(),
+}));
+
+vi.mock('../../src/prompts/project.js', () => ({
+  promptProjectName: vi.fn(),
+}));
+
+vi.mock('../../src/prompts/preset.js', () => ({
+  selectPreset: vi.fn(),
+  customizePreset: vi.fn(),
+}));
+
+vi.mock('../../src/prompts/packageManager.js', () => ({
+  promptPackageManager: vi.fn(),
+}));
+
+// Import after mocks are set up
+import { promptPlatforms } from '../../src/prompts/platform.js';
+import { promptORM } from '../../src/prompts/orm.js';
+import { promptFeatures } from '../../src/prompts/features.js';
+import { promptSDKs } from '../../src/prompts/sdks.js';
+import { promptOnboarding } from '../../src/prompts/onboarding.js';
+import { promptProjectName } from '../../src/prompts/project.js';
+import { selectPreset } from '../../src/prompts/preset.js';
+import { promptPackageManager } from '../../src/prompts/packageManager.js';
+import { collectConfiguration } from '../../src/prompts/index.js';
+
+describe('Conditional Prompts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Common mocks for all tests
+    vi.mocked(promptProjectName).mockResolvedValue('test-app');
+    vi.mocked(promptPackageManager).mockResolvedValue('npm');
+    // Return null from selectPreset to trigger custom configuration flow
+    vi.mocked(selectPreset).mockResolvedValue(null);
+  });
+
+  describe('promptFeatures with platform awareness', () => {
+    it('should return disabled onboarding for web-only platforms', async () => {
+      // This tests the actual promptFeatures implementation behavior
+      vi.mocked(promptFeatures).mockImplementation(async (platforms: string[] = ['mobile', 'web']) => {
+        const hasMobile = platforms.includes('mobile');
+        return {
+          onboarding: { enabled: hasMobile ? true : false, pages: 3, skipButton: true, showPaywall: false },
+          authentication: { enabled: true, providers: { emailPassword: true, google: false, apple: false, github: false } },
+          paywall: hasMobile ? false : false,
+          sessionManagement: true,
+        };
+      });
+
+      const result = await promptFeatures(['web']);
+      expect(result.onboarding.enabled).toBe(false);
+      expect(result.paywall).toBe(false);
+    });
+
+    it('should return enabled onboarding for mobile platforms', async () => {
+      vi.mocked(promptFeatures).mockImplementation(async (platforms: string[] = ['mobile', 'web']) => {
+        const hasMobile = platforms.includes('mobile');
+        return {
+          onboarding: { enabled: hasMobile, pages: 3, skipButton: true, showPaywall: false },
+          authentication: { enabled: true, providers: { emailPassword: true, google: false, apple: false, github: false } },
+          paywall: false,
+          sessionManagement: true,
+        };
+      });
+
+      const result = await promptFeatures(['mobile']);
+      expect(result.onboarding.enabled).toBe(true);
+    });
+  });
+
+  describe('SDK prompts conditional on platform', () => {
+    it('should skip SDK prompts for web-only projects', async () => {
+      // Set up mocks to simulate web-only flow
+      vi.mocked(promptPlatforms).mockResolvedValue(['web']);
+      vi.mocked(promptORM).mockResolvedValue('prisma');
+      vi.mocked(promptFeatures).mockResolvedValue({
+        onboarding: { enabled: false, pages: 3, skipButton: true, showPaywall: false },
+        authentication: { enabled: true, providers: { emailPassword: true, google: false, apple: false, github: false } },
+        paywall: false,
+        sessionManagement: true,
+      });
+
+      // Call collectConfiguration which triggers collectCustomConfiguration internally
+      await collectConfiguration(undefined, {});
+
+      // The key assertion: promptSDKs should NOT be called for web-only
+      expect(promptSDKs).not.toHaveBeenCalled();
+    });
+
+    it('should call SDK prompts for mobile projects', async () => {
+      vi.mocked(promptPlatforms).mockResolvedValue(['mobile']);
+      vi.mocked(promptORM).mockResolvedValue('prisma');
+      vi.mocked(promptFeatures).mockResolvedValue({
+        onboarding: { enabled: true, pages: 3, skipButton: true, showPaywall: false },
+        authentication: { enabled: true, providers: { emailPassword: true, google: false, apple: false, github: false } },
+        paywall: false,
+        sessionManagement: true,
+      });
+      vi.mocked(promptSDKs).mockResolvedValue({
+        revenueCat: { enabled: false, iosKey: '', androidKey: '' },
+        adjust: { enabled: false, appToken: '', environment: 'sandbox' },
+        scate: { enabled: false, apiKey: '' },
+        att: { enabled: false },
+      });
+      vi.mocked(promptOnboarding).mockResolvedValue({
+        pages: 3,
+        skipButton: true,
+        showPaywall: false,
+      });
+
+      await collectConfiguration(undefined, {});
+
+      expect(promptSDKs).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -159,4 +159,95 @@ describe('validateConfiguration', () => {
     config.integrations.revenueCat.enabled = true;
     expect(validateConfiguration(config).valid).toBe(true);
   });
+
+  describe('Mobile-only feature validation', () => {
+    it('should reject paywall on web-only project', () => {
+      const config = createValidConfig();
+      config.platforms = ['web'];
+      config.features.paywall = true;
+      // Even with RevenueCat enabled, platform check fails first
+      config.integrations.revenueCat.enabled = true;
+
+      const result = validateConfiguration(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('mobile platform');
+    });
+
+    it('should reject RevenueCat on web-only project', () => {
+      const config = createValidConfig();
+      config.platforms = ['web'];
+      config.integrations.revenueCat.enabled = true;
+
+      const result = validateConfiguration(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('mobile platform');
+    });
+
+    it('should reject Adjust on web-only project', () => {
+      const config = createValidConfig();
+      config.platforms = ['web'];
+      config.integrations.adjust.enabled = true;
+
+      const result = validateConfiguration(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('mobile platform');
+    });
+
+    it('should reject Scate on web-only project', () => {
+      const config = createValidConfig();
+      config.platforms = ['web'];
+      config.integrations.scate.enabled = true;
+
+      const result = validateConfiguration(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('mobile platform');
+    });
+
+    it('should reject ATT on web-only project', () => {
+      const config = createValidConfig();
+      config.platforms = ['web'];
+      config.integrations.att.enabled = true;
+
+      const result = validateConfiguration(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('mobile platform');
+    });
+
+    it('should reject onboarding on web-only project', () => {
+      const config = createValidConfig();
+      config.platforms = ['web'];
+      config.features.onboarding.enabled = true;
+      config.features.onboarding.pages = 3;
+
+      const result = validateConfiguration(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('mobile platform');
+    });
+
+    it('should accept mobile-only features on mobile project', () => {
+      const config = createValidConfig();
+      config.platforms = ['mobile'];
+      config.features.paywall = true;
+      config.features.onboarding.enabled = true;
+      config.features.onboarding.pages = 3;
+      config.integrations.revenueCat.enabled = true;
+      config.integrations.adjust.enabled = true;
+      config.integrations.att.enabled = true;
+
+      const result = validateConfiguration(config);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should accept mobile-only features on mobile+web project', () => {
+      const config = createValidConfig();
+      config.platforms = ['mobile', 'web'];
+      config.features.paywall = true;
+      config.features.onboarding.enabled = true;
+      config.features.onboarding.pages = 3;
+      config.integrations.revenueCat.enabled = true;
+
+      const result = validateConfiguration(config);
+      expect(result.valid).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add platform selection to preset customization flow
- Make prompts conditional on platform selection (mobile-only features hidden for web-only projects)
- Add validation for mobile-only features on web-only configurations

## Changes

### Prompt Updates

**`src/prompts/preset.ts`**
- Add platform selection as first prompt after customize confirmation
- Make onboarding, paywall, and SDK prompts conditional on mobile platform
- Update `displayPresetSummary()` to show platform configuration

**`src/prompts/index.ts`**
- Make SDK prompts conditional on mobile platform in custom flow
- Add `getDefaultIntegrations()` helper for web-only projects

**`src/prompts/features.ts`**
- Accept optional `platforms` parameter
- Conditionally show onboarding and paywall options based on platform
- Add "(mobile only)" labels to mobile-specific features

### Validation

**`src/utils/validation.ts`**
- Add validation for mobile-only features on web-only projects
- Platform checks run before dependency checks for clearer error messages

### Tests

- Add `tests/unit/prompts-conditional.test.ts` with 4 tests for platform-aware prompts
- Add 8 tests to `tests/unit/validation.test.ts` for mobile-only validation
- Update integration tests to include platform selection mocks

Closes #27