### PR TITLE
refactor(templates): separate repository and service layers in backend

### DIFF
--- a/templates/base/backend/controllers/rest-api/plugins/auth.ts
+++ b/templates/base/backend/controllers/rest-api/plugins/auth.ts
@@ -6,7 +6,8 @@ import type {
 import { FastifyPluginAsync, FastifyRequest, FastifyReply } from "fastify";
 import fp from "fastify-plugin";
 import { auth, Session } from "../../../lib/auth";
-import { validateDeviceSession, updateDeviceSessionActivity } from "../../../domain/device-session/repository";
+import { validateDeviceSession } from "../../../domain/device-session/service";
+import { updateDeviceSessionActivity } from "../../../domain/device-session/repository";
 import { DeviceSession } from "../../../domain/device-session/schema";
 import { ErrorFactory, normalizeError } from "../../../utils/errors";
 

--- a/templates/base/backend/controllers/rest-api/routes/auth.ts.ejs
+++ b/templates/base/backend/controllers/rest-api/routes/auth.ts.ejs
@@ -3,7 +3,8 @@ import { FastifyPluginAsync, FastifyRequest } from "fastify";
 import { auth } from "../../../lib/auth";
 import { Type } from "@sinclair/typebox";
 import { updateUserProfile, deleteUser, userHasPassword } from "../../../domain/user/repository";
-import { findUserSessionById, revokeSessionByToken } from "../../../domain/session/repository";
+import { findUserSessionById } from "../../../domain/session/repository";
+import { revokeSessionByToken } from "../../../domain/session/service";
 
 /**
  * Convert Fastify request to Fetch API Request for BetterAuth

--- a/templates/base/backend/controllers/rest-api/routes/device-sessions.ts
+++ b/templates/base/backend/controllers/rest-api/routes/device-sessions.ts
@@ -11,10 +11,12 @@ import {
 import {
   createDeviceSession,
   validateDeviceSession,
-  updateDeviceSessionActivity,
   validateDeviceSessionMigrationEligibility,
-  deleteDeviceSession,
   cleanupExpiredDeviceSessions,
+} from "../../../domain/device-session/service";
+import {
+  updateDeviceSessionActivity,
+  deleteDeviceSession,
 } from "../../../domain/device-session/repository";
 import { Type } from "@sinclair/typebox";
 

--- a/templates/base/backend/domain/device-session/repository.drizzle.ts
+++ b/templates/base/backend/domain/device-session/repository.drizzle.ts
@@ -1,52 +1,34 @@
 import { eq, lt } from 'drizzle-orm';
 import { db, schema } from "../../utils/db";
 import { ErrorFactory } from "../../utils/errors";
-import {
-  DeviceSession,
-  CreateDeviceSessionBody,
-  CreateDeviceSessionResponse,
-  DeviceSessionMigrationEligibilityResponse,
-} from "./schema";
+import { DeviceSession } from "./schema";
 
-const generateSessionToken = (): string => {
-  return crypto.randomUUID();
-};
+/**
+ * Device Session Repository (Drizzle)
+ *
+ * Pure database operations only. Business logic belongs in service.ts.
+ */
 
-export const createDeviceSession = async (data: CreateDeviceSessionBody): Promise<CreateDeviceSessionResponse> => {
-  const { deviceId } = data;
+// Helper to transform Drizzle session to API format
+const toDeviceSession = (session: {
+  id: string;
+  deviceId: string;
+  sessionToken: string;
+  createdAt: Date;
+  lastActiveAt: Date;
+  migrated: boolean;
+  migratedToUserId: string | null;
+  preferredCurrency: string;
+}): DeviceSession => ({
+  ...session,
+  createdAt: session.createdAt.toISOString(),
+  lastActiveAt: session.lastActiveAt.toISOString(),
+});
 
-  try {
-    const sessionToken = generateSessionToken();
-
-    const [session] = await db
-      .insert(schema.deviceSession)
-      .values({
-        deviceId,
-        sessionToken,
-        preferredCurrency: 'USD',
-        migrated: false,
-        lastActiveAt: new Date(),
-      })
-      .returning();
-
-    return {
-      session: {
-        ...session,
-        createdAt: session.createdAt.toISOString(),
-        lastActiveAt: session.lastActiveAt.toISOString(),
-      },
-      sessionToken,
-    };
-  } catch (error) {
-    throw ErrorFactory.databaseError({
-      operation: 'createDeviceSession',
-      deviceId,
-      originalError: error instanceof Error ? error.message : String(error)
-    });
-  }
-};
-
-export const validateDeviceSession = async (sessionToken: string): Promise<DeviceSession | null> => {
+/**
+ * Find a device session by token (pure fetch, no expiration logic)
+ */
+export const findDeviceSessionByToken = async (sessionToken: string): Promise<DeviceSession | null> => {
   try {
     const [session] = await db
       .select()
@@ -54,33 +36,72 @@ export const validateDeviceSession = async (sessionToken: string): Promise<Devic
       .where(eq(schema.deviceSession.sessionToken, sessionToken))
       .limit(1);
 
-    if (!session) {
-      return null;
-    }
-
-    // Check if session is expired (30 days of inactivity)
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-    if (session.lastActiveAt < thirtyDaysAgo) {
-      await deleteDeviceSession(sessionToken);
-      return null;
-    }
-
-    return {
-      ...session,
-      createdAt: session.createdAt.toISOString(),
-      lastActiveAt: session.lastActiveAt.toISOString(),
-    };
+    return session ? toDeviceSession(session) : null;
   } catch (error) {
     throw ErrorFactory.databaseError({
-      operation: 'validateDeviceSession',
+      operation: 'findDeviceSessionByToken',
       sessionToken,
       originalError: error instanceof Error ? error.message : String(error)
     });
   }
 };
 
+/**
+ * Find a device session by ID (pure fetch)
+ */
+export const getDeviceSessionById = async (sessionId: string): Promise<DeviceSession | null> => {
+  try {
+    const [session] = await db
+      .select()
+      .from(schema.deviceSession)
+      .where(eq(schema.deviceSession.id, sessionId))
+      .limit(1);
+
+    return session ? toDeviceSession(session) : null;
+  } catch (error) {
+    throw ErrorFactory.databaseError({
+      operation: 'getDeviceSessionById',
+      sessionId,
+      originalError: error instanceof Error ? error.message : String(error)
+    });
+  }
+};
+
+/**
+ * Insert a new device session (pure insert with all fields provided)
+ */
+export const insertDeviceSession = async (data: {
+  deviceId: string;
+  sessionToken: string;
+  preferredCurrency: string;
+  migrated: boolean;
+  lastActiveAt: Date;
+}): Promise<DeviceSession> => {
+  try {
+    const [session] = await db
+      .insert(schema.deviceSession)
+      .values({
+        deviceId: data.deviceId,
+        sessionToken: data.sessionToken,
+        preferredCurrency: data.preferredCurrency,
+        migrated: data.migrated,
+        lastActiveAt: data.lastActiveAt,
+      })
+      .returning();
+
+    return toDeviceSession(session);
+  } catch (error) {
+    throw ErrorFactory.databaseError({
+      operation: 'insertDeviceSession',
+      deviceId: data.deviceId,
+      originalError: error instanceof Error ? error.message : String(error)
+    });
+  }
+};
+
+/**
+ * Update device session activity timestamp (pure DB update)
+ */
 export const updateDeviceSessionActivity = async (sessionToken: string): Promise<void> => {
   try {
     await db
@@ -96,6 +117,9 @@ export const updateDeviceSessionActivity = async (sessionToken: string): Promise
   }
 };
 
+/**
+ * Delete a device session by token (pure DB delete)
+ */
 export const deleteDeviceSession = async (sessionToken: string): Promise<void> => {
   try {
     await db
@@ -110,36 +134,28 @@ export const deleteDeviceSession = async (sessionToken: string): Promise<void> =
   }
 };
 
-export const validateDeviceSessionMigrationEligibility = async (sessionToken: string): Promise<DeviceSessionMigrationEligibilityResponse> => {
+/**
+ * Delete expired device sessions (pure batch delete with provided threshold)
+ */
+export const deleteExpiredDeviceSessions = async (threshold: Date): Promise<number> => {
   try {
-    const session = await validateDeviceSession(sessionToken);
+    const result = await db
+      .delete(schema.deviceSession)
+      .where(lt(schema.deviceSession.lastActiveAt, threshold))
+      .returning({ id: schema.deviceSession.id });
 
-    if (!session) {
-      return {
-        canMigrate: false,
-        reason: 'Device session not found or expired',
-      };
-    }
-
-    if (session.migrated) {
-      return {
-        canMigrate: false,
-        reason: 'Device session already migrated to user account',
-      };
-    }
-
-    return {
-      canMigrate: true,
-    };
+    return result.length;
   } catch (error) {
     throw ErrorFactory.databaseError({
-      operation: 'validateDeviceSessionMigrationEligibility',
-      sessionToken,
+      operation: 'deleteExpiredDeviceSessions',
       originalError: error instanceof Error ? error.message : String(error)
     });
   }
 };
 
+/**
+ * Migrate a device session to a user account (pure DB update)
+ */
 export const migrateDeviceSessionToUser = async (sessionToken: string, userId: string): Promise<void> => {
   try {
     await db
@@ -157,53 +173,4 @@ export const migrateDeviceSessionToUser = async (sessionToken: string, userId: s
       originalError: error instanceof Error ? error.message : String(error)
     });
   }
-};
-
-export const cleanupExpiredDeviceSessions = async (): Promise<number> => {
-  try {
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-    const result = await db
-      .delete(schema.deviceSession)
-      .where(lt(schema.deviceSession.lastActiveAt, thirtyDaysAgo))
-      .returning({ id: schema.deviceSession.id });
-
-    return result.length;
-  } catch (error) {
-    throw ErrorFactory.databaseError({
-      operation: 'cleanupExpiredDeviceSessions',
-      originalError: error instanceof Error ? error.message : String(error)
-    });
-  }
-};
-
-export const getDeviceSessionById = async (sessionId: string): Promise<DeviceSession | null> => {
-  try {
-    const [session] = await db
-      .select()
-      .from(schema.deviceSession)
-      .where(eq(schema.deviceSession.id, sessionId))
-      .limit(1);
-
-    if (!session) {
-      return null;
-    }
-
-    return {
-      ...session,
-      createdAt: session.createdAt.toISOString(),
-      lastActiveAt: session.lastActiveAt.toISOString(),
-    };
-  } catch (error) {
-    throw ErrorFactory.databaseError({
-      operation: 'getDeviceSessionById',
-      sessionId,
-      originalError: error instanceof Error ? error.message : String(error)
-    });
-  }
-};
-
-export const getDeviceSessionByToken = async (sessionToken: string): Promise<DeviceSession | null> => {
-  return validateDeviceSession(sessionToken);
 };

--- a/templates/base/backend/domain/device-session/service.ts
+++ b/templates/base/backend/domain/device-session/service.ts
@@ -1,0 +1,129 @@
+import {
+  findDeviceSessionByToken,
+  insertDeviceSession,
+  deleteDeviceSession,
+  deleteExpiredDeviceSessions,
+} from "./repository";
+import {
+  DeviceSession,
+  CreateDeviceSessionBody,
+  CreateDeviceSessionResponse,
+  DeviceSessionMigrationEligibilityResponse,
+} from "./schema";
+
+/**
+ * Device Session Service
+ *
+ * Business logic that orchestrates repository calls.
+ * This file is ORM-agnostic - it imports from ./repository which resolves
+ * to the correct implementation (Prisma or Drizzle) at generation time.
+ */
+
+// Generate a UUID v4 for session tokens
+const generateSessionToken = (): string => {
+  return crypto.randomUUID();
+};
+
+// Session expiration threshold (30 days of inactivity)
+const EXPIRATION_DAYS = 30;
+
+const getExpirationThreshold = (): Date => {
+  const threshold = new Date();
+  threshold.setDate(threshold.getDate() - EXPIRATION_DAYS);
+  return threshold;
+};
+
+/**
+ * Create a new device session with generated token and default values
+ */
+export const createDeviceSession = async (
+  data: CreateDeviceSessionBody
+): Promise<CreateDeviceSessionResponse> => {
+  const { deviceId } = data;
+  const sessionToken = generateSessionToken();
+
+  const session = await insertDeviceSession({
+    deviceId,
+    sessionToken,
+    preferredCurrency: 'USD',
+    migrated: false,
+    lastActiveAt: new Date(),
+  });
+
+  return {
+    session,
+    sessionToken,
+  };
+};
+
+/**
+ * Validate a device session - checks existence and expiration (30 days)
+ * Deletes expired sessions automatically
+ */
+export const validateDeviceSession = async (
+  sessionToken: string
+): Promise<DeviceSession | null> => {
+  const session = await findDeviceSessionByToken(sessionToken);
+
+  if (!session) {
+    return null;
+  }
+
+  // Check if session is expired (30 days of inactivity)
+  const threshold = getExpirationThreshold();
+  const lastActive = new Date(session.lastActiveAt);
+
+  if (lastActive < threshold) {
+    // Session expired, delete it
+    await deleteDeviceSession(sessionToken);
+    return null;
+  }
+
+  return session;
+};
+
+/**
+ * Check if a device session is eligible for migration to a user account
+ */
+export const validateDeviceSessionMigrationEligibility = async (
+  sessionToken: string
+): Promise<DeviceSessionMigrationEligibilityResponse> => {
+  const session = await validateDeviceSession(sessionToken);
+
+  if (!session) {
+    return {
+      canMigrate: false,
+      reason: 'Device session not found or expired',
+    };
+  }
+
+  if (session.migrated) {
+    return {
+      canMigrate: false,
+      reason: 'Device session already migrated to user account',
+    };
+  }
+
+  return {
+    canMigrate: true,
+  };
+};
+
+/**
+ * Clean up expired device sessions (older than 30 days)
+ * Returns the number of deleted sessions
+ */
+export const cleanupExpiredDeviceSessions = async (): Promise<number> => {
+  const threshold = getExpirationThreshold();
+  return deleteExpiredDeviceSessions(threshold);
+};
+
+/**
+ * Get a device session by token (validates and returns if valid)
+ * Alias for validateDeviceSession for semantic clarity
+ */
+export const getDeviceSessionByToken = async (
+  sessionToken: string
+): Promise<DeviceSession | null> => {
+  return validateDeviceSession(sessionToken);
+};

--- a/templates/base/backend/domain/session/repository.drizzle.ts
+++ b/templates/base/backend/domain/session/repository.drizzle.ts
@@ -1,13 +1,12 @@
 import { eq, and } from 'drizzle-orm';
 import { db, schema } from "../../utils/db";
-import { auth } from "../../lib/auth";
 import { ErrorFactory } from "../../utils/errors";
-import type { SessionWithToken, RevokeSessionResponse } from "./schema";
+import type { SessionWithToken } from "./schema";
 
 /**
  * Session Repository (Drizzle)
  *
- * Provides session management operations for the BFF pattern.
+ * Pure database operations only. Business logic belongs in service.ts.
  * Note: Session creation/authentication is handled by BetterAuth.
  */
 
@@ -44,28 +43,6 @@ export const findUserSessionById = async (
       operation: 'findUserSessionById',
       sessionId,
       userId,
-      originalError: error instanceof Error ? error.message : String(error),
-    });
-  }
-};
-
-/**
- * Revoke a session using Better Auth's native revocation
- */
-export const revokeSessionByToken = async (
-  token: string,
-  headers: Headers
-): Promise<RevokeSessionResponse> => {
-  try {
-    const response = await auth.api.revokeSession({
-      headers,
-      body: { token },
-    });
-
-    return response as RevokeSessionResponse;
-  } catch (error) {
-    throw ErrorFactory.databaseError({
-      operation: 'revokeSessionByToken',
       originalError: error instanceof Error ? error.message : String(error),
     });
   }

--- a/templates/base/backend/domain/session/repository.prisma.ts
+++ b/templates/base/backend/domain/session/repository.prisma.ts
@@ -1,12 +1,11 @@
 import { db } from "../../utils/db";
-import { auth } from "../../lib/auth";
 import { ErrorFactory } from "../../utils/errors";
-import type { SessionWithToken, RevokeSessionResponse } from "./schema";
+import type { SessionWithToken } from "./schema";
 
 /**
  * Session Repository (Prisma)
  *
- * Provides session management operations for the BFF pattern.
+ * Pure database operations only. Business logic belongs in service.ts.
  * Note: Session creation/authentication is handled by BetterAuth.
  */
 
@@ -44,28 +43,6 @@ export const findUserSessionById = async (
       operation: 'findUserSessionById',
       sessionId,
       userId,
-      originalError: error instanceof Error ? error.message : String(error),
-    });
-  }
-};
-
-/**
- * Revoke a session using Better Auth's native revocation
- */
-export const revokeSessionByToken = async (
-  token: string,
-  headers: Headers
-): Promise<RevokeSessionResponse> => {
-  try {
-    const response = await auth.api.revokeSession({
-      headers,
-      body: { token },
-    });
-
-    return response as RevokeSessionResponse;
-  } catch (error) {
-    throw ErrorFactory.databaseError({
-      operation: 'revokeSessionByToken',
       originalError: error instanceof Error ? error.message : String(error),
     });
   }

--- a/templates/base/backend/domain/session/service.ts
+++ b/templates/base/backend/domain/session/service.ts
@@ -1,0 +1,33 @@
+import { auth } from "../../lib/auth";
+import { ErrorFactory } from "../../utils/errors";
+import type { RevokeSessionResponse } from "./schema";
+
+/**
+ * Session Service
+ *
+ * Business logic that orchestrates repository calls and external services.
+ * This file is ORM-agnostic - repository operations are imported from ./repository.
+ */
+
+/**
+ * Revoke a session using Better Auth's native revocation API
+ * This is an external service call, not a database operation
+ */
+export const revokeSessionByToken = async (
+  token: string,
+  headers: Headers
+): Promise<RevokeSessionResponse> => {
+  try {
+    const response = await auth.api.revokeSession({
+      headers,
+      body: { token },
+    });
+
+    return response as RevokeSessionResponse;
+  } catch (error) {
+    throw ErrorFactory.externalServiceError('BetterAuth', {
+      operation: 'revokeSession',
+      originalError: error instanceof Error ? error.message : String(error),
+    });
+  }
+};


### PR DESCRIPTION
## Summary

- Extract business logic from repository files into dedicated service files
- Keep repository files as pure database operation layers (Prisma + Drizzle)
- Update consumers to import from the correct layer

## Changes

### Service Layer (new)

**`domain/device-session/service.ts`**
- Session creation with UUID generation and default values
- Session validation with 30-day expiration check
- Migration eligibility checks
- Expired session cleanup orchestration

**`domain/session/service.ts`**
- BetterAuth session revocation using `externalServiceError` (was incorrectly `databaseError`)

### Repository Layer (refactored)

**`domain/device-session/repository.{prisma,drizzle}.ts`**
- Pure DB operations only: `findDeviceSessionByToken`, `insertDeviceSession`, `deleteExpiredDeviceSessions`, `getDeviceSessionById`, `updateDeviceSessionActivity`, `deleteDeviceSession`, `migrateDeviceSessionToUser`
- Removed business logic (expiration checks, UUID generation, migration eligibility)

**`domain/session/repository.{prisma,drizzle}.ts`**
- Removed `revokeSessionByToken` (moved to service with correct error type)

### Consumers (updated imports)

- `routes/device-sessions.ts` — business logic from service, DB ops from repository
- `routes/auth.ts.ejs` — `revokeSessionByToken` from service
- `plugins/auth.ts` — `validateDeviceSession` from service

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (279 tests, 25 files)
- [x] Template system includes new service files automatically (`base/backend/` path)

Closes #39