### PR TITLE
feat(cli): add AI coding tool selection for guideline file generation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { ProjectGenerator } from './generators/index.js';
 import { displaySuccess, errors } from './utils/errors.js';
 import { validatePackageManager } from './utils/system-validation.js';
 import type { ProjectConfig, CLIOptions } from './types/index.js';
+import { AI_TOOL_FILES } from './types/index.js';
 
 export async function runCLI(
   projectName: string | undefined,
@@ -128,6 +129,11 @@ function displayConfigSummary(config: ProjectConfig): void {
   console.log(`  ${chalk.bold('Integrations:')} ${integrations}`);
 
   console.log(`  ${chalk.bold('Package Manager:')} ${config.packageManager}`);
+
+  const aiToolsDisplay = config.aiTools.length
+    ? config.aiTools.map(t => AI_TOOL_FILES[t]).join(', ')
+    : 'None';
+  console.log(`  ${chalk.bold('AI Tools:')} ${aiToolsDisplay}`);
   console.log();
 }
 

--- a/src/config/presets.ts
+++ b/src/config/presets.ts
@@ -56,6 +56,7 @@ export const PRESETS: PresetDefinition[] = [
       },
       preset: 'minimal',
       customized: false,
+      aiTools: ['codex'],
     },
   },
   {
@@ -113,6 +114,7 @@ export const PRESETS: PresetDefinition[] = [
       },
       preset: 'full-featured',
       customized: false,
+      aiTools: ['codex'],
     },
   },
   {
@@ -170,6 +172,7 @@ export const PRESETS: PresetDefinition[] = [
       },
       preset: 'analytics-focused',
       customized: false,
+      aiTools: ['codex'],
     },
   },
 ];

--- a/src/prompts/aiTools.ts
+++ b/src/prompts/aiTools.ts
@@ -1,0 +1,20 @@
+import inquirer from 'inquirer';
+import type { AITool } from '../types/index.js';
+
+export async function promptAITools(): Promise<AITool[]> {
+  const { aiTools } = await inquirer.prompt([
+    {
+      type: 'checkbox',
+      name: 'aiTools',
+      message: 'Which AI coding tools do you use?',
+      choices: [
+        { name: 'Claude Code', value: 'claude' },
+        { name: 'Codex (OpenAI)', value: 'codex' },
+        { name: 'Cursor', value: 'cursor' },
+        { name: 'Windsurf', value: 'windsurf' },
+      ],
+    },
+  ]);
+
+  return aiTools;
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -6,6 +6,7 @@ import { promptOnboarding } from './onboarding.js';
 import { promptPackageManager } from './packageManager.js';
 import { promptORM } from './orm.js';
 import { promptPlatforms } from './platform.js';
+import { promptAITools } from './aiTools.js';
 import inquirer from 'inquirer';
 import { PRESETS } from '../config/presets.js';
 import type { ProjectConfig, CLIOptions } from '../types/index.js';
@@ -21,12 +22,14 @@ export async function collectConfiguration(
   // 2. If --template flag is provided, load that preset
   if (options.template) {
     const config = await loadPresetByName(options.template);
+    const aiTools = await promptAITools();
     const packageManager = await promptPackageManager();
     return {
       ...config,
       projectName: name,
       appScheme: deriveAppScheme(name),
       packageManager,
+      aiTools,
     };
   }
 
@@ -57,7 +60,10 @@ export async function collectConfiguration(
     config.integrations.att.enabled = true;
   }
 
-  // 6. Get package manager
+  // 6. Get AI coding tools preference
+  const aiTools = await promptAITools();
+
+  // 7. Get package manager
   const packageManager = await promptPackageManager();
 
   return {
@@ -65,6 +71,7 @@ export async function collectConfiguration(
     projectName: name,
     appScheme: deriveAppScheme(name),
     packageManager,
+    aiTools,
   };
 }
 
@@ -115,6 +122,7 @@ async function collectCustomConfiguration(): Promise<
     },
     preset: 'custom',
     customized: false,
+    aiTools: [],
   };
 }
 

--- a/src/prompts/preset.ts
+++ b/src/prompts/preset.ts
@@ -2,6 +2,7 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { PRESETS } from '../config/presets.js';
 import type { ProjectConfig } from '../types/index.js';
+import { AI_TOOL_FILES } from '../types/index.js';
 
 export async function selectPreset(): Promise<
   Omit<ProjectConfig, 'projectName' | 'packageManager' | 'appScheme'> | null
@@ -245,5 +246,9 @@ function displayPresetSummary(
   console.log(
     chalk.gray(`  • GitHub OAuth: ${config.features.authentication.providers.github ? 'Yes' : 'No'}`)
   );
+  const aiToolsDisplay = config.aiTools?.length
+    ? config.aiTools.map(t => AI_TOOL_FILES[t]).join(', ')
+    : 'None';
+  console.log(chalk.gray(`  • AI Tools: ${aiToolsDisplay}`));
   console.log();
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,17 @@ export type ORMChoice = 'prisma' | 'drizzle';
 // Platform choices (mobile = Expo, web = Next.js)
 export type Platform = 'mobile' | 'web';
 
+// AI coding tool choices
+export type AITool = 'claude' | 'codex' | 'cursor' | 'windsurf';
+
+// Maps each AI tool to its convention filename
+export const AI_TOOL_FILES: Record<AITool, string> = {
+  claude: 'CLAUDE.md',
+  codex: 'AGENTS.md',
+  cursor: '.cursorrules',
+  windsurf: '.windsurfrules',
+};
+
 export interface ProjectConfig {
   // Project metadata
   projectName: string;
@@ -71,6 +82,9 @@ export interface ProjectConfig {
   // Preset information
   preset?: 'minimal' | 'full-featured' | 'analytics-focused' | 'custom';
   customized: boolean;
+
+  // AI coding tools (determines which guideline files are generated)
+  aiTools: AITool[];
 }
 
 export interface PresetDefinition {

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -40,6 +40,11 @@ export function shouldIncludeFile(
     return false;
   }
 
+  // Skip AGENTS.md - AI tool guideline files are generated dynamically
+  if (filePath.includes('shared/AGENTS.md')) {
+    return false;
+  }
+
   // ==========================================================================
   // Platform-based filtering (consistent architecture)
   // ==========================================================================

--- a/templates/shared/AGENTS.md.ejs
+++ b/templates/shared/AGENTS.md.ejs
@@ -39,7 +39,7 @@ The hierarchy flows: **Root → App → Feature folder**
 
 ```
 <%= projectName %>/
-├── AGENTS.md                    # This file
+├── <%= guidelineFileName %>                    # This file
 ├── DESIGN.md                    # System architecture
 │
 ├── backend/

--- a/tests/e2e/project-generation.test.ts
+++ b/tests/e2e/project-generation.test.ts
@@ -65,6 +65,7 @@ describe('E2E: Full Project Generation', () => {
       },
       preset: 'minimal',
       customized: false,
+      aiTools: ['codex'],
     };
 
     const generator = new ProjectGenerator(config);
@@ -140,6 +141,7 @@ describe('E2E: Full Project Generation', () => {
       },
       preset: 'full-featured',
       customized: false,
+      aiTools: ['codex'],
     };
 
     const generator = new ProjectGenerator(config);
@@ -226,6 +228,7 @@ describe('E2E: Full Project Generation', () => {
       },
       preset: 'minimal',
       customized: false,
+      aiTools: ['codex'],
     };
 
     const generator = new ProjectGenerator(config);
@@ -288,6 +291,7 @@ describe('E2E: Full Project Generation', () => {
       },
       preset: 'custom',
       customized: false,
+      aiTools: ['codex'],
     };
 
     const generator = new ProjectGenerator(config);
@@ -355,6 +359,7 @@ describe('E2E: Full Project Generation', () => {
         },
         preset: 'custom',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -422,6 +427,7 @@ describe('E2E: Full Project Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -478,6 +484,7 @@ describe('E2E: Full Project Generation', () => {
         },
         preset: 'custom',
         customized: true,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -549,6 +556,7 @@ describe('E2E: Full Project Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -608,6 +616,7 @@ describe('E2E: Full Project Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);

--- a/tests/fixtures/configs/analytics-focused.ts
+++ b/tests/fixtures/configs/analytics-focused.ts
@@ -36,4 +36,5 @@ export const analyticsFocusedConfig: Readonly<ProjectConfig> = {
   },
   preset: 'analytics-focused',
   customized: false,
+  aiTools: ['codex'],
 } as const;

--- a/tests/fixtures/configs/drizzle-config.ts
+++ b/tests/fixtures/configs/drizzle-config.ts
@@ -38,4 +38,5 @@ export const drizzleConfig: Omit<ProjectConfig, 'projectName' | 'packageManager'
   },
   preset: 'custom',
   customized: false,
+  aiTools: ['codex'],
 };

--- a/tests/fixtures/configs/full-featured.ts
+++ b/tests/fixtures/configs/full-featured.ts
@@ -36,4 +36,5 @@ export const fullFeaturedConfig: Readonly<ProjectConfig> = {
   },
   preset: 'full-featured',
   customized: false,
+  aiTools: ['codex'],
 } as const;

--- a/tests/fixtures/configs/index.ts
+++ b/tests/fixtures/configs/index.ts
@@ -82,5 +82,6 @@ export function createTestConfig(
       ...minimalConfig.backend,
       ...overrides.backend,
     },
+    aiTools: overrides.aiTools ?? [...minimalConfig.aiTools],
   };
 }

--- a/tests/fixtures/configs/minimal.ts
+++ b/tests/fixtures/configs/minimal.ts
@@ -36,4 +36,5 @@ export const minimalConfig: Readonly<ProjectConfig> = {
   },
   preset: 'minimal',
   customized: false,
+  aiTools: ['codex'],
 } as const;

--- a/tests/fixtures/configs/mobile-only.ts
+++ b/tests/fixtures/configs/mobile-only.ts
@@ -36,4 +36,5 @@ export const mobileOnlyConfig: Readonly<ProjectConfig> = {
   },
   preset: 'minimal',
   customized: false,
+  aiTools: ['codex'],
 } as const;

--- a/tests/fixtures/configs/web-minimal.ts
+++ b/tests/fixtures/configs/web-minimal.ts
@@ -36,4 +36,5 @@ export const webMinimalConfig: Readonly<ProjectConfig> = {
   },
   preset: 'minimal',
   customized: false,
+  aiTools: ['codex'],
 } as const;

--- a/tests/fixtures/configs/web-only.ts
+++ b/tests/fixtures/configs/web-only.ts
@@ -36,4 +36,5 @@ export const webOnlyConfig: Readonly<ProjectConfig> = {
   },
   preset: 'minimal',
   customized: false,
+  aiTools: ['codex'],
 } as const;

--- a/tests/fixtures/configs/web-with-oauth.ts
+++ b/tests/fixtures/configs/web-with-oauth.ts
@@ -36,4 +36,5 @@ export const webWithOAuthConfig: Readonly<ProjectConfig> = {
   },
   preset: 'custom',
   customized: true,
+  aiTools: ['codex'],
 } as const;

--- a/tests/integration/copy.test.ts
+++ b/tests/integration/copy.test.ts
@@ -44,6 +44,7 @@ describe('Copy Utils', () => {
     },
     preset: 'minimal',
     customized: false,
+    aiTools: ['codex'],
   };
 
   beforeEach(async () => {

--- a/tests/integration/full-flow.test.ts
+++ b/tests/integration/full-flow.test.ts
@@ -20,8 +20,10 @@ describe('Integration Tests - Prompt Flows', () => {
 
   describe('--template flag behavior', () => {
     it('should load minimal preset with --template minimal', async () => {
-      // Mock package manager prompt only
-      inquirer.prompt.mockResolvedValueOnce({ packageManager: 'npm' });
+      // Mock AI tools + package manager prompts
+      inquirer.prompt
+        .mockResolvedValueOnce({ aiTools: ['codex'] }) // AI tools
+        .mockResolvedValueOnce({ packageManager: 'npm' }); // Package manager
 
       const options: CLIOptions = { template: 'minimal' };
       const config = await collectConfiguration('test-app', options);
@@ -35,7 +37,9 @@ describe('Integration Tests - Prompt Flows', () => {
     });
 
     it('should load full-featured preset with --template full-featured', async () => {
-      inquirer.prompt.mockResolvedValueOnce({ packageManager: 'yarn' });
+      inquirer.prompt
+        .mockResolvedValueOnce({ aiTools: [] })
+        .mockResolvedValueOnce({ packageManager: 'yarn' });
 
       const options: CLIOptions = { template: 'full-featured' };
       const config = await collectConfiguration('my-app', options);
@@ -53,7 +57,9 @@ describe('Integration Tests - Prompt Flows', () => {
     });
 
     it('should load analytics-focused preset with --template analytics-focused', async () => {
-      inquirer.prompt.mockResolvedValueOnce({ packageManager: 'bun' });
+      inquirer.prompt
+        .mockResolvedValueOnce({ aiTools: ['claude'] })
+        .mockResolvedValueOnce({ packageManager: 'bun' });
 
       const options: CLIOptions = { template: 'analytics-focused' };
       const config = await collectConfiguration('analytics-app', options);
@@ -107,6 +113,7 @@ describe('Integration Tests - Prompt Flows', () => {
       inquirer.prompt
         .mockResolvedValueOnce({ preset: 'Minimal' }) // Select preset
         .mockResolvedValueOnce({ customize: false }) // Don't customize
+        .mockResolvedValueOnce({ aiTools: ['codex'] }) // AI tools
         .mockResolvedValueOnce({ packageManager: 'npm' }); // Package manager
 
       const options: CLIOptions = {};
@@ -132,6 +139,7 @@ describe('Integration Tests - Prompt Flows', () => {
           scate: false,
           oauthProviders: ['google', 'apple'], // OAuth provider selection
         })
+        .mockResolvedValueOnce({ aiTools: ['claude', 'cursor'] }) // AI tools
         .mockResolvedValueOnce({ packageManager: 'npm' }); // Package manager
 
       const options: CLIOptions = {};
@@ -179,6 +187,7 @@ describe('Integration Tests - Prompt Flows', () => {
           showPaywall: true,
         })
         .mockResolvedValueOnce({ eventQueue: true }) // Event queue
+        .mockResolvedValueOnce({ aiTools: ['codex'] }) // AI tools
         .mockResolvedValueOnce({ packageManager: 'yarn' }); // Package manager
 
       const options: CLIOptions = {};
@@ -216,6 +225,7 @@ describe('Integration Tests - Prompt Flows', () => {
         })
         .mockResolvedValueOnce({ sdks: [] })
         .mockResolvedValueOnce({ eventQueue: false }) // Event queue
+        .mockResolvedValueOnce({ aiTools: [] }) // AI tools
         .mockResolvedValueOnce({ packageManager: 'npm' });
 
       const options: CLIOptions = {};
@@ -224,8 +234,8 @@ describe('Integration Tests - Prompt Flows', () => {
       expect(config.features.onboarding.enabled).toBe(false);
       expect(config.backend.orm).toBe('drizzle');
       expect(config.backend.eventQueue).toBe(false);
-      // custom, platforms, orm, features, auth details, sdks, eventQueue, package manager = 8
-      expect(inquirer.prompt).toHaveBeenCalledTimes(8);
+      // custom, platforms, orm, features, auth details, sdks, eventQueue, aiTools, package manager = 9
+      expect(inquirer.prompt).toHaveBeenCalledTimes(9);
     });
 
     it('should auto-enable ATT when Adjust is selected', async () => {
@@ -241,6 +251,7 @@ describe('Integration Tests - Prompt Flows', () => {
         })
         .mockResolvedValueOnce({ sdks: ['adjust', 'scate'] })
         .mockResolvedValueOnce({ eventQueue: true }) // Event queue
+        .mockResolvedValueOnce({ aiTools: ['codex'] }) // AI tools
         .mockResolvedValueOnce({ packageManager: 'npm' });
 
       const options: CLIOptions = {};
@@ -263,6 +274,7 @@ describe('Integration Tests - Prompt Flows', () => {
     it('should prompt for project name if not provided', async () => {
       inquirer.prompt
         .mockResolvedValueOnce({ projectName: 'prompted-name' })
+        .mockResolvedValueOnce({ aiTools: [] })
         .mockResolvedValueOnce({ packageManager: 'npm' });
 
       const options: CLIOptions = { template: 'minimal' };
@@ -282,6 +294,7 @@ describe('Integration Tests - Prompt Flows', () => {
         .mockResolvedValueOnce({ features: [] })
         .mockResolvedValueOnce({ sdks: [] })
         .mockResolvedValueOnce({ eventQueue: true }) // Event queue
+        .mockResolvedValueOnce({ aiTools: ['codex'] }) // AI tools
         .mockResolvedValueOnce({ packageManager: 'npm' });
 
       const options: CLIOptions = {};
@@ -301,6 +314,7 @@ describe('Integration Tests - Prompt Flows', () => {
         .mockResolvedValueOnce({ features: [] })
         .mockResolvedValueOnce({ sdks: [] })
         .mockResolvedValueOnce({ eventQueue: true }) // Event queue
+        .mockResolvedValueOnce({ aiTools: ['windsurf'] }) // AI tools
         .mockResolvedValueOnce({ packageManager: 'npm' });
 
       const options: CLIOptions = {};

--- a/tests/integration/preset-edge-cases.test.ts
+++ b/tests/integration/preset-edge-cases.test.ts
@@ -69,6 +69,7 @@ describe('Preset Edge Cases', () => {
       },
       preset: 'minimal',
       customized: false,
+      aiTools: ['codex'],
     };
 
     it('should validate onboarding pages range (too low)', async () => {

--- a/tests/integration/web-generator.test.ts
+++ b/tests/integration/web-generator.test.ts
@@ -61,6 +61,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -110,6 +111,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -156,6 +158,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -216,6 +219,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -260,6 +264,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -307,6 +312,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -353,6 +359,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -408,6 +415,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'custom',
         customized: true,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -456,6 +464,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -502,6 +511,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'custom',
         customized: true,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -555,6 +565,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -597,6 +608,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -641,6 +653,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -695,6 +708,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);
@@ -745,6 +759,7 @@ describe('Integration: Web Template Generation', () => {
         },
         preset: 'minimal',
         customized: false,
+        aiTools: ['codex'],
       };
 
       const generator = new ProjectGenerator(config);

--- a/tests/unit/onboarding.test.ts
+++ b/tests/unit/onboarding.test.ts
@@ -48,6 +48,7 @@ describe('Onboarding Generator', () => {
       },
       preset: 'minimal',
       customized: false,
+      aiTools: ['codex'],
     };
 
     await generateOnboardingPages(config, tempDir);
@@ -88,6 +89,7 @@ describe('Onboarding Generator', () => {
       },
       preset: 'custom',
       customized: false,
+      aiTools: ['codex'],
     };
 
     await generateOnboardingPages(config, tempDir);
@@ -129,6 +131,7 @@ describe('Onboarding Generator', () => {
       },
       preset: 'custom',
       customized: false,
+      aiTools: ['codex'],
     };
 
     await generateOnboardingPages(config, tempDir);
@@ -184,6 +187,7 @@ describe('Onboarding Generator', () => {
       },
       preset: 'custom',
       customized: false,
+      aiTools: ['codex'],
     };
 
     await generateOnboardingPages(config, tempDir);
@@ -229,6 +233,7 @@ describe('Onboarding Generator', () => {
       },
       preset: 'custom',
       customized: false,
+      aiTools: ['codex'],
     };
 
     await generateOnboardingPages(config, tempDir);
@@ -273,6 +278,7 @@ describe('Onboarding Generator', () => {
       },
       preset: 'custom',
       customized: false,
+      aiTools: ['codex'],
     };
 
     await generateOnboardingPages(config, tempDir);

--- a/tests/unit/package.test.ts
+++ b/tests/unit/package.test.ts
@@ -25,6 +25,7 @@ describe('Package Utils', () => {
     },
     preset: 'minimal',
     customized: false,
+    aiTools: ['codex'],
   };
 
   describe('buildMobilePackageJson', () => {

--- a/tests/unit/template.test.ts
+++ b/tests/unit/template.test.ts
@@ -39,6 +39,7 @@ describe('Template Utils', () => {
     },
     preset: 'custom',
     customized: false,
+    aiTools: ['codex'],
   };
 
   describe('shouldIncludeFile', () => {
@@ -103,6 +104,10 @@ describe('Template Utils', () => {
     it('should always exclude .gitkeep files', () => {
       expect(shouldIncludeFile('base/mobile/src/.gitkeep', mockConfig)).toBe(false);
       expect(shouldIncludeFile('features/mobile/auth/.gitkeep', mockConfig)).toBe(false);
+    });
+
+    it('should exclude shared/AGENTS.md.ejs (generated dynamically)', () => {
+      expect(shouldIncludeFile('shared/AGENTS.md.ejs', mockConfig)).toBe(false);
     });
   });
 

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -106,6 +106,7 @@ describe('validateConfiguration', () => {
     },
     preset: 'minimal',
     customized: false,
+    aiTools: ['codex'] as const,
   });
 
   it('should accept valid configuration', () => {


### PR DESCRIPTION
## Summary

- Add multi-select prompt asking users which AI coding tools they use (Claude Code, Codex, Cursor, Windsurf)
- Generate the correct convention file(s) at the project root: `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.windsurfrules`
- Each file self-references its own filename in the documentation tree
- Empty selection generates no guideline file; multiple tools generate multiple files
- Presets default to `['codex']` for backward compatibility with existing behavior

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (287/287)
- [x] Single tool selection generates correct file with self-reference
- [x] Multiple tool selection generates multiple files, each with correct self-reference
- [x] Empty selection generates no guideline files
- [x] `--defaults` uses preset value (no prompt, generates `AGENTS.md`)
- [x] Interactive, custom, and `--template` flows all include AI tools prompt

Closes #47