### PR TITLE
fix(cli): scaffold package.json and Next.js config for auth/web dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Single-project mode. The closest equivalent is `npx create-stackr myapp --defaults --no-auth --service-name core`, which produces a minimal monorepo with a single base service.
 
+### Fixed
+
+- **`auth/web` admin dashboard now scaffolds the full Next.js project shell** (`package.json`, `tsconfig.json`, `next.config.ts`, `postcss.config.mjs`, `eslint.config.mjs`, `components.json`, `.env.example`, `.gitignore`, `.prettierrc`, `.prettierignore`, `src/app/layout.tsx`, `src/app/globals.css`, `src/components/ui/*`). Previously the symmetric kind filter in `shouldIncludeFile` was written against `services/base/` and dropped every file under `services/base/web/**` for auth services, leaving `auth/web/` with only the auth feature pages and no project shell — the directory could not be installed or built. The predicates are now narrowed to `services/{auth,base}/backend/` so they gate only the per-kind backend divergence, matching the documented intent of `ServiceGenerator.pickSubtrees`. (#52)
+
 ### Deferred (tracked in backlog)
 
 - `stackr add auth` — retroactively add an auth service to a `--no-auth` project

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -50,12 +50,16 @@ export function shouldIncludeFile(
     return false;
   }
 
-  // Only the auth service should consume templates/services/auth/**
-  if (filePath.includes('services/auth/') && ctx.service.kind !== 'auth') {
+  // Per-kind backend divergence: only the auth service renders the auth
+  // backend tree, and only non-auth services render the base backend tree.
+  // The web/mobile trees under `services/base/{web,mobile}/` are shared
+  // scaffolding that applies to every service with the respective platform
+  // enabled (see ServiceGenerator.pickSubtrees), so they must NOT be gated
+  // by these predicates.
+  if (filePath.includes('services/auth/backend/') && ctx.service.kind !== 'auth') {
     return false;
   }
-  // Symmetrically, non-auth services don't render auth-specific trees
-  if (filePath.includes('services/base/') && ctx.service.kind === 'auth') {
+  if (filePath.includes('services/base/backend/') && ctx.service.kind === 'auth') {
     return false;
   }
 

--- a/tests/integration/project-generator-web.test.ts
+++ b/tests/integration/project-generator-web.test.ts
@@ -68,6 +68,35 @@ describe('path mapping (web / features)', () => {
       shouldIncludeFile('features/web/auth/app/(auth)/login/page.tsx.ejs', noAuthCtx)
     ).toBe(false);
   });
+
+  it('shouldIncludeFile includes services/base/web files for auth services with web enabled', () => {
+    // Regression guard: the symmetric kind filter used to drop every file
+    // under services/base/** for auth services, which also stripped the
+    // shared Next.js scaffolding under services/base/web/**. The filter is
+    // now narrowed to services/base/backend/, so base web must flow through.
+    const authWebCfg = cloneInitConfig(fullFeaturedConfig);
+    const authSvc = authWebCfg.services.find((s) => s.kind === 'auth')!;
+    const authCtx = buildServiceContext(authWebCfg, authSvc);
+    expect(shouldIncludeFile('services/base/web/next.config.ts', authCtx)).toBe(true);
+    expect(shouldIncludeFile('services/base/web/package.json.ejs', authCtx)).toBe(true);
+    expect(shouldIncludeFile('services/base/web/tsconfig.json', authCtx)).toBe(true);
+  });
+
+  it('shouldIncludeFile still excludes services/base/backend files for auth services', () => {
+    const authCfg = cloneInitConfig(fullFeaturedConfig);
+    const authSvc = authCfg.services.find((s) => s.kind === 'auth')!;
+    const authCtx = buildServiceContext(authCfg, authSvc);
+    expect(shouldIncludeFile('services/base/backend/lib/constants.ts.ejs', authCtx)).toBe(false);
+    expect(shouldIncludeFile('services/base/backend/package.json.ejs', authCtx)).toBe(false);
+  });
+
+  it('shouldIncludeFile still excludes services/auth/backend files for base services', () => {
+    const baseCfg = cloneInitConfig(fullFeaturedConfig);
+    const baseSvc = baseCfg.services.find((s) => s.kind === 'base')!;
+    const baseCtx = buildServiceContext(baseCfg, baseSvc);
+    expect(shouldIncludeFile('services/auth/backend/lib/auth.ts.ejs', baseCtx)).toBe(false);
+    expect(shouldIncludeFile('services/auth/backend/package.json.ejs', baseCtx)).toBe(false);
+  });
 });
 
 describe('project generator — web subtree', () => {
@@ -192,5 +221,114 @@ describe('project generator — web-only service (mobile disabled)', () => {
   it('generates core/web but not core/mobile', async () => {
     expect(await fs.pathExists(path.join(projectDir, 'core/web'))).toBe(true);
     expect(await fs.pathExists(path.join(projectDir, 'core/mobile'))).toBe(false);
+  });
+});
+
+describe('project generator — auth/web subtree (admin dashboard)', () => {
+  // Regression coverage for #52: when the auth service has adminDashboard
+  // enabled, auth/web must be scaffolded with the same root Next.js shell
+  // (package.json, tsconfig, next.config, shadcn ui, etc.) as core/web.
+  // Previously a too-broad kind filter in shouldIncludeFile stripped every
+  // file under services/base/web/** for auth services, leaving auth/web/
+  // with only the auth feature pages layered from features/web/auth/**.
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeAll(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'project-gen-authweb-'));
+    const cfg = cloneInitConfig(fullFeaturedConfig);
+    cfg.projectName = 'test-auth-web';
+    cfg.appScheme = 'testauthweb';
+    // fullFeaturedConfig already sets adminDashboard: true and populates
+    // auth.web from the authEntry factory, so no extra mutation is needed.
+    projectDir = path.join(tempDir, cfg.projectName);
+    await new MonorepoGenerator(cfg).generate(projectDir);
+  });
+
+  afterAll(async () => {
+    await fs.remove(tempDir);
+  });
+
+  it('creates auth/web/ directory with src/app/, src/components/, src/lib/', async () => {
+    expect(await fs.pathExists(path.join(projectDir, 'auth/web'))).toBe(true);
+    expect(await fs.pathExists(path.join(projectDir, 'auth/web/src/app'))).toBe(true);
+    expect(await fs.pathExists(path.join(projectDir, 'auth/web/src/components'))).toBe(true);
+    expect(await fs.pathExists(path.join(projectDir, 'auth/web/src/lib'))).toBe(true);
+  });
+
+  it('lands next.config.ts / components.json / eslint.config.mjs / postcss.config.mjs / tsconfig.json in auth/web/', async () => {
+    for (const f of [
+      'next.config.ts',
+      'components.json',
+      'eslint.config.mjs',
+      'postcss.config.mjs',
+      'tsconfig.json',
+    ]) {
+      expect(
+        await fs.pathExists(path.join(projectDir, 'auth/web', f)),
+        `missing auth/web/${f}`
+      ).toBe(true);
+    }
+  });
+
+  it('lands package.json / .env.example / .gitignore / .prettierrc / .prettierignore in auth/web/', async () => {
+    for (const f of [
+      'package.json',
+      '.env.example',
+      '.gitignore',
+      '.prettierrc',
+      '.prettierignore',
+    ]) {
+      expect(
+        await fs.pathExists(path.join(projectDir, 'auth/web', f)),
+        `missing auth/web/${f}`
+      ).toBe(true);
+    }
+  });
+
+  it('auth/web package.json name is <projectName>-auth-web and parses as JSON', async () => {
+    const raw = await fs.readFile(path.join(projectDir, 'auth/web/package.json'), 'utf-8');
+    const pkg = JSON.parse(raw);
+    expect(pkg.name).toBe('test-auth-web-auth-web');
+    expect(pkg.scripts?.dev).toBe('next dev');
+    expect(pkg.dependencies?.next).toBeDefined();
+    expect(pkg.dependencies?.react).toBeDefined();
+  });
+
+  it('lands the root layout.tsx and globals.css in auth/web/src/app/', async () => {
+    expect(
+      await fs.pathExists(path.join(projectDir, 'auth/web/src/app/layout.tsx'))
+    ).toBe(true);
+    expect(
+      await fs.pathExists(path.join(projectDir, 'auth/web/src/app/globals.css'))
+    ).toBe(true);
+  });
+
+  it('generates shadcn UI primitives under auth/web/src/components/ui/', async () => {
+    for (const f of ['button.tsx', 'card.tsx', 'input.tsx', 'label.tsx']) {
+      expect(
+        await fs.pathExists(path.join(projectDir, 'auth/web/src/components/ui', f)),
+        `missing auth/web/src/components/ui/${f}`
+      ).toBe(true);
+    }
+  });
+
+  it('still renders the auth service backend (no regression from narrowed kind filter)', async () => {
+    expect(await fs.pathExists(path.join(projectDir, 'auth/backend'))).toBe(true);
+    expect(
+      await fs.pathExists(path.join(projectDir, 'auth/backend/package.json'))
+    ).toBe(true);
+  });
+
+  it('does not render the base backend tree into auth/ (kind filter still guards backends)', async () => {
+    // Smoke check: auth/backend's package.json must be the auth-service
+    // variant, not the base backend variant — the narrowed kind filter
+    // should still keep services/base/backend/** out of the auth service.
+    const raw = await fs.readFile(
+      path.join(projectDir, 'auth/backend/package.json'),
+      'utf-8'
+    );
+    const pkg = JSON.parse(raw);
+    expect(pkg.name).toBe('test-auth-web-auth-backend');
   });
 });


### PR DESCRIPTION
## Summary

- **Narrow the symmetric kind filters in `shouldIncludeFile`** (`src/utils/template.ts:53-60`) from `services/{auth,base}/` → `services/{auth,base}/backend/`. The previous predicate stripped every file under `services/base/web/**` and `services/base/mobile/**` from auth service output, leaving `auth/web/` without `package.json`, `tsconfig.json`, `next.config.ts`, and the rest of the Next.js shell.
- **Regression coverage** in `tests/integration/project-generator-web.test.ts` — new describe block that generates an auth service with `adminDashboard: true` and asserts the full Next.js scaffold lands in `auth/web/`, plus targeted `shouldIncludeFile` unit assertions confirming the narrowed filter still blocks the backend trees.
- **No template changes, no generator-logic changes.** `ServiceGenerator.pickSubtrees()` already schedules `services/base/web` for auth services and `SIMPLE_PATH_MAPPINGS` already maps it correctly — only the filter was wrong.
- CHANGELOG entry added under the in-progress `[0.5.0]` section.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new warnings/errors; 12 pre-existing warnings unchanged)
- [x] `npm test` — 402/402 tests pass across 46 files, including 14 new assertions for `auth/web` scaffolding and the narrowed `shouldIncludeFile` predicates
- [x] `auth/backend` continues to render from `services/auth/backend/**` (regression guard in the new describe block)
- [x] `core/web` output unchanged (existing `core/web` assertions still pass)

Closes #52