### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker required for backend development
 - PostgreSQL and Redis required for full features
 
+[0.5.0]: https://github.com/itharea/create-stackr/releases/tag/v0.5.0
 [0.4.0]: https://github.com/itharea/create-stackr/releases/tag/v0.4.0
 [0.3.1]: https://github.com/itharea/create-stackr/releases/tag/v0.3.1
 [0.3.0]: https://github.com/itharea/create-stackr/releases/tag/v0.3.0

--- a/README.md
+++ b/README.md
@@ -617,6 +617,16 @@ A: Yes, Next.js App Router uses React Server Components by default. Client compo
 
 ## Roadmap
 
+### Completed in v0.5.0
+- [x] Multi-microservice monorepo scaffolding (`auth/` + one or more base services)
+- [x] Second CLI binary: `stackr add service <name>` for post-init service scaffolding
+- [x] `stackr.config.json` durable source of truth written at generation time
+- [x] Three auth middleware flavors (standard, role-gated, flexible) with HTTP forwarding
+- [x] Marker-block `docker-compose.yml` regeneration that preserves user edits
+- [x] Pending-migration sentinel (`stackr migrations ack`) for auth schema changes
+- [x] Programmatic docker-compose + per-service env prefixing (`AUTH_DB_*`, `CORE_DB_*`, …)
+- [x] Root `package.json` with `create-stackr` pinned as a devDependency so `npx stackr` works inside generated projects
+
 ### Completed in v0.4.0
 - [x] AI coding tool selection (Claude Code, Codex, Cursor, Windsurf)
 - [x] Architectural documentation (DESIGN.md, BEST_PRACTICES.md) in generated projects
@@ -640,7 +650,7 @@ A: Yes, Next.js App Router uses React Server Components by default. Client compo
 - [x] Email verification & password reset
 
 ### Upcoming
-- [ ] v0.5.0: More SDK integrations (Firebase, Supabase)
+- [ ] v0.6.0: `stackr add auth` (retroactively add auth to a `--no-auth` project), `stackr migrate` (automated DB migrations via docker or host mode), more SDK integrations (Firebase, Supabase)
 - [ ] v1.0.0: Stable API, production-ready
 
 ## Technology Stack


### PR DESCRIPTION
## Summary

- Add v0.5.0 link to CHANGELOG footer
- Add "Completed in v0.5.0" section to README roadmap
- Update "Upcoming" roadmap to point at v0.6.0

The v0.5.0 feature work (multi-microservice monorepo scaffolding) already merged via #51, followed by the post-release fixes #53, #56, and #58. `package.json` was bumped to `0.5.0` and the full `[0.5.0] - 2026-04-11` changelog body was written as part of #51. This release PR only ships the docs/roadmap catch-up needed before tagging.

## Changes in v0.5.0

### ⚠ BREAKING CHANGES

- Default project layout is now a multi-microservice monorepo (`auth/ + core/ + …`) instead of a single `backend/ + mobile/ + web/`. v0.4 projects keep working as-is but are not automatically migrated.
- New second CLI binary `stackr` for post-init operations (`stackr add service`, `stackr migrations ack`).
- `stackr.config.json` is now the durable source of truth, written at generation time.

### Added

- Multi-service monorepo scaffolding with `--with-services`, `--no-auth`, `--service-name`
- `stackr add service <name>` subcommand with atomic five-phase write pipeline
- `stackr migrations ack <service>` escape hatch for manual DB migrations
- Three auth middleware flavors (standard / role-gated / flexible)
- Marker-block `docker-compose.yml` regeneration preserving user edits
- Pending-migration sentinel in `stackr.config.json`
- Shared `Dockerfile` and auth-plugin templates
- Deterministic port allocation (auth=8082, base backends from 8080, web from 3000)

### Fixed (post-release)

- `auth/web` admin dashboard now scaffolds the full Next.js project shell (#52)
- Root `.env` and per-service `backend/.env` get real random credentials at init time (#54)
- `setup.sh` offers a confirmed docker-volume reset after rotating env credentials (#55)
- Generated monorepos ship a root `package.json` so the `stackr` CLI is runnable via `npx stackr` inside them (#57)

See [CHANGELOG.md](https://github.com/itharea/create-stackr/blob/release/v0.5.0/CHANGELOG.md) for the full entry.

## After Merge

After merging this PR, create and push the tag to trigger the release:

```bash
git checkout main
git pull
git tag v0.5.0
git push origin v0.5.0
```