### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-04-14
+
+### Fixed
+
+- **Web `.env.local` generation**: `create-stackr` now copies `web/.env.example` to `web/.env.local` at init time with correct service-specific ports (backend URL, app URL, auth service URL). `setup.sh` also creates them as a safety net. Base web `.env.example.ejs` updated to use service context ports instead of hardcoded 3000/8080.
+- **Auth admin dashboard**: Added `templates/services/auth/web/` with a complete admin dashboard — login page (admin-only), dashboard with user stats, user list with search/role filtering, user detail with role management and deletion. `ServiceGenerator.pickSubtrees()` and `shouldIncludeFile()` updated to route auth services to the new template tree instead of the generic base web + features/web overlay.
+
 ## [0.5.0] - 2026-04-11
 
 ### ⚠ BREAKING CHANGES
@@ -204,6 +211,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker required for backend development
 - PostgreSQL and Redis required for full features
 
+[0.5.1]: https://github.com/itharea/create-stackr/releases/tag/v0.5.1
 [0.5.0]: https://github.com/itharea/create-stackr/releases/tag/v0.5.0
 [0.4.0]: https://github.com/itharea/create-stackr/releases/tag/v0.4.0
 [0.3.1]: https://github.com/itharea/create-stackr/releases/tag/v0.3.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-stackr",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Scaffold production-ready multi-microservice monorepos with Fastify backends, BetterAuth, Docker, and more",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version from 0.5.0 to 0.5.1
- Add v0.5.1 changelog entry
- Add v0.5.1 link to CHANGELOG footer

## Changes in v0.5.1

### Fixed

- **Web `.env.local` generation**: `create-stackr` now copies `web/.env.example` to `web/.env.local` at init time with correct service-specific ports (backend URL, app URL, auth service URL). `setup.sh` also creates them as a safety net. Base web `.env.example.ejs` updated to use service context ports instead of hardcoded 3000/8080. (#60)
- **Auth admin dashboard**: Added `templates/services/auth/web/` with a complete admin dashboard — login page (admin-only), dashboard with user stats, user list with search/role filtering, user detail with role management and deletion. `ServiceGenerator.pickSubtrees()` and `shouldIncludeFile()` updated to route auth services to the new template tree instead of the generic base web + features/web overlay. (#60)

## After Merge

After merging this PR, create and push the tag to trigger the release:

```bash
git checkout main
git pull
git tag v0.5.1
git push origin v0.5.1
```