### PR TITLE
feat(cli): testing infra phase 4 — queue component tests

### DIFF
--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -140,6 +140,16 @@ export function shouldIncludeFile(
     return false;
   }
 
+  // Queue component tests — only when this service runs a worker.
+  if (filePath.includes('/tests/component/queue/') && !ctx.backend.eventQueue) {
+    return false;
+  }
+
+  // Queue test helper — same gate. Without this it ships even when no queue tests do.
+  if (filePath.endsWith('tests/helpers/bullmq.ts.ejs') && !ctx.backend.eventQueue) {
+    return false;
+  }
+
   // Admin routes — only include when auth admin dashboard is enabled
   if (filePath.includes('controllers/rest-api/routes/admin') && !ctx.service.authConfig?.adminDashboard) {
     return false;

--- a/templates/services/auth/backend/tests/component/queue/user-worker.test.ts.ejs
+++ b/templates/services/auth/backend/tests/component/queue/user-worker.test.ts.ejs
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { createTestQueue, createTestWorker, waitForJob, waitForJobSettled, closeQueueResources, closeConnection } from '../../helpers/bullmq.js';
+import { getShortUnique } from '../../helpers/unique.js';
+
+describe('queue semantics — BullMQ + Redis', () => {
+  afterAll(closeConnection);
+
+  describe('ack on success', () => {
+    it('marks job completed when handler returns', async () => {
+      const qName = `users-ack-${getShortUnique()}`;
+      const queue = createTestQueue(qName);
+      const worker = createTestWorker(qName, async () => ({ ok: true }));
+
+      try {
+        const job = await queue.add('welcome', { userId: getShortUnique() });
+        await waitForJob(worker, job.id!, 'completed');
+        const state = await job.getState();
+        expect(state).toBe('completed');
+      } finally {
+        await closeQueueResources(queue, worker);
+      }
+    });
+  });
+
+  describe('nack on failure', () => {
+    it('marks job failed after attempts exhausted and increments attemptsMade', async () => {
+      const qName = `users-nack-${getShortUnique()}`;
+      const queue = createTestQueue(qName);
+      const worker = createTestWorker(qName, async () => { throw new Error('boom'); });
+
+      try {
+        const job = await queue.add('welcome', { userId: 'x' }, { attempts: 1 });
+        await waitForJob(worker, job.id!, 'failed');
+        const state = await job.getState();
+        const reloaded = await queue.getJob(job.id!);
+        expect(state).toBe('failed');
+        expect(reloaded!.attemptsMade).toBe(1);
+      } finally {
+        await closeQueueResources(queue, worker);
+      }
+    });
+  });
+
+  describe('idempotency', () => {
+    it('dedupes identical jobId across enqueues', async () => {
+      const qName = `users-idem-${getShortUnique()}`;
+      const queue = createTestQueue(qName);
+      let processedCount = 0;
+      const worker = createTestWorker(qName, async () => { processedCount++; return { ok: true }; });
+
+      try {
+        const jobId = `welcome-${getShortUnique()}`;
+        const job1 = await queue.add('welcome', { userId: 'u1' }, { jobId });
+        const job2 = await queue.add('welcome', { userId: 'u1' }, { jobId });
+        expect(job2.id).toBe(job1.id);  // BullMQ returns the existing job for duplicate jobId
+        await waitForJob(worker, job1.id!, 'completed');
+        const counts = await queue.getJobCounts('completed', 'active', 'waiting');
+        expect(counts.completed).toBe(1);
+        expect(counts.active).toBe(0);
+        expect(counts.waiting).toBe(0);
+        expect(processedCount).toBe(1);
+      } finally {
+        await closeQueueResources(queue, worker);
+      }
+    });
+  });
+
+  describe('batch partial failure', () => {
+    it('completes 4 of 5 when one handler throws', async () => {
+      const qName = `users-batch-${getShortUnique()}`;
+      const queue = createTestQueue(qName);
+      const worker = createTestWorker<{ userId: string }>(qName, async ({ data }) => {
+        if (data.userId === 'bad') throw new Error('failed');
+        return { ok: true };
+      }, { concurrency: 5 });
+
+      try {
+        const ids = ['a', 'b', 'bad', 'c', 'd'];
+        const jobs = await Promise.all(ids.map(id => queue.add('welcome', { userId: id }, { attempts: 1 })));
+
+        const outcomes = await Promise.all(jobs.map(j => waitForJobSettled(worker, j.id!, 5000)));
+        expect(outcomes.filter(o => o === 'completed')).toHaveLength(4);
+        expect(outcomes.filter(o => o === 'failed')).toHaveLength(1);
+
+        const counts = await queue.getJobCounts('completed', 'failed');
+        expect(counts.completed).toBe(4);
+        expect(counts.failed).toBe(1);
+      } finally {
+        await closeQueueResources(queue, worker);
+      }
+    });
+  });
+});

--- a/templates/services/auth/backend/tests/helpers/bullmq.ts.ejs
+++ b/templates/services/auth/backend/tests/helpers/bullmq.ts.ejs
@@ -1,0 +1,116 @@
+import { Queue, Worker, type Processor, type QueueOptions, type WorkerOptions } from 'bullmq';
+import IORedis, { type Redis } from 'ioredis';
+
+// Singleton per Vitest worker process. Forks share no state, so one connection
+// per fork is correct. BullMQ treats externally-supplied connections as shared
+// and will not call `.quit()` on them when a Worker/Queue closes, so reusing
+// this across tests in the same file is safe.
+let connection: Redis | null = null;
+
+function getConnection(): Redis {
+  if (!connection || connection.status === 'end') {
+    connection = new IORedis({
+      host: process.env.REDIS_HOST,
+      port: Number(process.env.REDIS_PORT),
+      password: process.env.REDIS_PASSWORD,
+      maxRetriesPerRequest: null,   // BullMQ requirement
+    });
+  }
+  return connection;
+}
+
+export function createTestQueue<T = unknown>(name: string, opts: Partial<QueueOptions> = {}) {
+  return new Queue<T>(name, { connection: getConnection(), ...opts });
+}
+
+export function createTestWorker<T = unknown>(
+  name: string,
+  processor: Processor<T>,
+  opts: Partial<WorkerOptions> = {}
+) {
+  return new Worker<T>(name, processor, { connection: getConnection(), concurrency: 1, ...opts });
+}
+
+export async function closeQueueResources(queue: Queue, worker: Worker): Promise<void> {
+  await worker.close();
+  await queue.close();
+}
+
+export async function closeConnection(): Promise<void> {
+  if (connection) { connection.disconnect(); connection = null; }
+}
+
+/**
+ * Await a specific job's terminal state. Listens for both `completed` and
+ * `failed` so the losing branch never dangles as an unhandled rejection.
+ * If the opposite of the expected event fires, the promise rejects — so a
+ * test that asked for `completed` fails loudly when the job actually failed.
+ */
+export function waitForJob(
+  worker: Worker,
+  jobId: string,
+  event: 'completed' | 'failed' = 'completed',
+  timeoutMs = 5000
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      worker.off('completed', onCompleted);
+      worker.off('failed', onFailed);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for job ${jobId} (${event})`));
+    }, timeoutMs);
+    const onCompleted = (job: { id?: string }) => {
+      if (job.id !== jobId) return;
+      cleanup();
+      if (event === 'completed') resolve();
+      else reject(new Error(`Expected ${event} but job ${jobId} completed`));
+    };
+    const onFailed = (job: { id?: string }, err?: Error) => {
+      if (job.id !== jobId) return;
+      cleanup();
+      if (event === 'failed') resolve();
+      else reject(err ?? new Error(`Expected ${event} but job ${jobId} failed`));
+    };
+    worker.on('completed', onCompleted);
+    worker.on('failed', onFailed);
+  });
+}
+
+/**
+ * Resolve with whichever terminal state the job reaches. Use this when the
+ * caller wants to assert on the mix of outcomes across a batch — avoids the
+ * `Promise.race([waitForJob(...'completed'), waitForJob(...'failed')])`
+ * antipattern that leaks the losing branch's timer.
+ */
+export function waitForJobSettled(
+  worker: Worker,
+  jobId: string,
+  timeoutMs = 5000
+): Promise<'completed' | 'failed'> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      worker.off('completed', onCompleted);
+      worker.off('failed', onFailed);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for job ${jobId}`));
+    }, timeoutMs);
+    const onCompleted = (job: { id?: string }) => {
+      if (job.id !== jobId) return;
+      cleanup();
+      resolve('completed');
+    };
+    const onFailed = (job: { id?: string }) => {
+      if (job.id !== jobId) return;
+      cleanup();
+      resolve('failed');
+    };
+    worker.on('completed', onCompleted);
+    worker.on('failed', onFailed);
+  });
+}

--- a/templates/services/auth/backend/tests/helpers/global-setup.drizzle.ts.ejs
+++ b/templates/services/auth/backend/tests/helpers/global-setup.drizzle.ts.ejs
@@ -1,5 +1,15 @@
 import { execa } from 'execa';
 import nock from 'nock';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// globalSetup runs in the main Vitest process before any test worker
+// spins up, so the `setupFiles` env loader hasn't fired yet. Load the
+// same env files here so DATABASE_URL / REDIS_* are available below.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../../.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test'), override: true });
 
 async function waitForPostgres(url: string, timeoutMs = 30000) {
   const { Client } = await import('pg');

--- a/templates/services/auth/backend/tests/helpers/global-setup.prisma.ts.ejs
+++ b/templates/services/auth/backend/tests/helpers/global-setup.prisma.ts.ejs
@@ -1,5 +1,15 @@
 import { execa } from 'execa';
 import nock from 'nock';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// globalSetup runs in the main Vitest process before any test worker
+// spins up, so the `setupFiles` env loader hasn't fired yet. Load the
+// same env files here so DATABASE_URL / REDIS_* are available below.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../../.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test'), override: true });
 
 async function waitForPostgres(url: string, timeoutMs = 30000) {
   const { Client } = await import('pg');
@@ -40,7 +50,7 @@ export default async function globalSetup() {
   await waitForPostgres(process.env.DATABASE_URL!);
   await waitForRedis(process.env.REDIS_HOST!, Number(process.env.REDIS_PORT!), process.env.REDIS_PASSWORD!);
 
-  await execa('bun', ['x', 'prisma', 'db', 'push', '--accept-data-loss', '--skip-generate'], {
+  await execa('bun', ['x', 'prisma', 'db', 'push', '--accept-data-loss'], {
     env: { ...process.env, DATABASE_URL: process.env.DATABASE_URL },
     stdio: 'inherit',
   });

--- a/templates/services/base/backend/tests/component/queue/user-worker.test.ts.ejs
+++ b/templates/services/base/backend/tests/component/queue/user-worker.test.ts.ejs
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { createTestQueue, createTestWorker, waitForJob, waitForJobSettled, closeQueueResources, closeConnection } from '../../helpers/bullmq.js';
+import { getShortUnique } from '../../helpers/unique.js';
+
+describe('queue semantics — BullMQ + Redis', () => {
+  afterAll(closeConnection);
+
+  describe('ack on success', () => {
+    it('marks job completed when handler returns', async () => {
+      const qName = `users-ack-${getShortUnique()}`;
+      const queue = createTestQueue(qName);
+      const worker = createTestWorker(qName, async () => ({ ok: true }));
+
+      try {
+        const job = await queue.add('welcome', { userId: getShortUnique() });
+        await waitForJob(worker, job.id!, 'completed');
+        const state = await job.getState();
+        expect(state).toBe('completed');
+      } finally {
+        await closeQueueResources(queue, worker);
+      }
+    });
+  });
+
+  describe('nack on failure', () => {
+    it('marks job failed after attempts exhausted and increments attemptsMade', async () => {
+      const qName = `users-nack-${getShortUnique()}`;
+      const queue = createTestQueue(qName);
+      const worker = createTestWorker(qName, async () => { throw new Error('boom'); });
+
+      try {
+        const job = await queue.add('welcome', { userId: 'x' }, { attempts: 1 });
+        await waitForJob(worker, job.id!, 'failed');
+        const state = await job.getState();
+        const reloaded = await queue.getJob(job.id!);
+        expect(state).toBe('failed');
+        expect(reloaded!.attemptsMade).toBe(1);
+      } finally {
+        await closeQueueResources(queue, worker);
+      }
+    });
+  });
+
+  describe('idempotency', () => {
+    it('dedupes identical jobId across enqueues', async () => {
+      const qName = `users-idem-${getShortUnique()}`;
+      const queue = createTestQueue(qName);
+      let processedCount = 0;
+      const worker = createTestWorker(qName, async () => { processedCount++; return { ok: true }; });
+
+      try {
+        const jobId = `welcome-${getShortUnique()}`;
+        const job1 = await queue.add('welcome', { userId: 'u1' }, { jobId });
+        const job2 = await queue.add('welcome', { userId: 'u1' }, { jobId });
+        expect(job2.id).toBe(job1.id);  // BullMQ returns the existing job for duplicate jobId
+        await waitForJob(worker, job1.id!, 'completed');
+        const counts = await queue.getJobCounts('completed', 'active', 'waiting');
+        expect(counts.completed).toBe(1);
+        expect(counts.active).toBe(0);
+        expect(counts.waiting).toBe(0);
+        expect(processedCount).toBe(1);
+      } finally {
+        await closeQueueResources(queue, worker);
+      }
+    });
+  });
+
+  describe('batch partial failure', () => {
+    it('completes 4 of 5 when one handler throws', async () => {
+      const qName = `users-batch-${getShortUnique()}`;
+      const queue = createTestQueue(qName);
+      const worker = createTestWorker<{ userId: string }>(qName, async ({ data }) => {
+        if (data.userId === 'bad') throw new Error('failed');
+        return { ok: true };
+      }, { concurrency: 5 });
+
+      try {
+        const ids = ['a', 'b', 'bad', 'c', 'd'];
+        const jobs = await Promise.all(ids.map(id => queue.add('welcome', { userId: id }, { attempts: 1 })));
+
+        const outcomes = await Promise.all(jobs.map(j => waitForJobSettled(worker, j.id!, 5000)));
+        expect(outcomes.filter(o => o === 'completed')).toHaveLength(4);
+        expect(outcomes.filter(o => o === 'failed')).toHaveLength(1);
+
+        const counts = await queue.getJobCounts('completed', 'failed');
+        expect(counts.completed).toBe(4);
+        expect(counts.failed).toBe(1);
+      } finally {
+        await closeQueueResources(queue, worker);
+      }
+    });
+  });
+});

--- a/templates/services/base/backend/tests/helpers/bullmq.ts.ejs
+++ b/templates/services/base/backend/tests/helpers/bullmq.ts.ejs
@@ -1,0 +1,116 @@
+import { Queue, Worker, type Processor, type QueueOptions, type WorkerOptions } from 'bullmq';
+import IORedis, { type Redis } from 'ioredis';
+
+// Singleton per Vitest worker process. Forks share no state, so one connection
+// per fork is correct. BullMQ treats externally-supplied connections as shared
+// and will not call `.quit()` on them when a Worker/Queue closes, so reusing
+// this across tests in the same file is safe.
+let connection: Redis | null = null;
+
+function getConnection(): Redis {
+  if (!connection || connection.status === 'end') {
+    connection = new IORedis({
+      host: process.env.REDIS_HOST,
+      port: Number(process.env.REDIS_PORT),
+      password: process.env.REDIS_PASSWORD,
+      maxRetriesPerRequest: null,   // BullMQ requirement
+    });
+  }
+  return connection;
+}
+
+export function createTestQueue<T = unknown>(name: string, opts: Partial<QueueOptions> = {}) {
+  return new Queue<T>(name, { connection: getConnection(), ...opts });
+}
+
+export function createTestWorker<T = unknown>(
+  name: string,
+  processor: Processor<T>,
+  opts: Partial<WorkerOptions> = {}
+) {
+  return new Worker<T>(name, processor, { connection: getConnection(), concurrency: 1, ...opts });
+}
+
+export async function closeQueueResources(queue: Queue, worker: Worker): Promise<void> {
+  await worker.close();
+  await queue.close();
+}
+
+export async function closeConnection(): Promise<void> {
+  if (connection) { connection.disconnect(); connection = null; }
+}
+
+/**
+ * Await a specific job's terminal state. Listens for both `completed` and
+ * `failed` so the losing branch never dangles as an unhandled rejection.
+ * If the opposite of the expected event fires, the promise rejects — so a
+ * test that asked for `completed` fails loudly when the job actually failed.
+ */
+export function waitForJob(
+  worker: Worker,
+  jobId: string,
+  event: 'completed' | 'failed' = 'completed',
+  timeoutMs = 5000
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      worker.off('completed', onCompleted);
+      worker.off('failed', onFailed);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for job ${jobId} (${event})`));
+    }, timeoutMs);
+    const onCompleted = (job: { id?: string }) => {
+      if (job.id !== jobId) return;
+      cleanup();
+      if (event === 'completed') resolve();
+      else reject(new Error(`Expected ${event} but job ${jobId} completed`));
+    };
+    const onFailed = (job: { id?: string }, err?: Error) => {
+      if (job.id !== jobId) return;
+      cleanup();
+      if (event === 'failed') resolve();
+      else reject(err ?? new Error(`Expected ${event} but job ${jobId} failed`));
+    };
+    worker.on('completed', onCompleted);
+    worker.on('failed', onFailed);
+  });
+}
+
+/**
+ * Resolve with whichever terminal state the job reaches. Use this when the
+ * caller wants to assert on the mix of outcomes across a batch — avoids the
+ * `Promise.race([waitForJob(...'completed'), waitForJob(...'failed')])`
+ * antipattern that leaks the losing branch's timer.
+ */
+export function waitForJobSettled(
+  worker: Worker,
+  jobId: string,
+  timeoutMs = 5000
+): Promise<'completed' | 'failed'> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      worker.off('completed', onCompleted);
+      worker.off('failed', onFailed);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for job ${jobId}`));
+    }, timeoutMs);
+    const onCompleted = (job: { id?: string }) => {
+      if (job.id !== jobId) return;
+      cleanup();
+      resolve('completed');
+    };
+    const onFailed = (job: { id?: string }) => {
+      if (job.id !== jobId) return;
+      cleanup();
+      resolve('failed');
+    };
+    worker.on('completed', onCompleted);
+    worker.on('failed', onFailed);
+  });
+}

--- a/templates/services/base/backend/tests/helpers/global-setup.drizzle.ts.ejs
+++ b/templates/services/base/backend/tests/helpers/global-setup.drizzle.ts.ejs
@@ -1,5 +1,15 @@
 import { execa } from 'execa';
 import nock from 'nock';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// globalSetup runs in the main Vitest process before any test worker
+// spins up, so the `setupFiles` env loader hasn't fired yet. Load the
+// same env files here so DATABASE_URL / REDIS_* are available below.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../../.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test'), override: true });
 
 async function waitForPostgres(url: string, timeoutMs = 30000) {
   const { Client } = await import('pg');

--- a/templates/services/base/backend/tests/helpers/global-setup.prisma.ts.ejs
+++ b/templates/services/base/backend/tests/helpers/global-setup.prisma.ts.ejs
@@ -1,5 +1,15 @@
 import { execa } from 'execa';
 import nock from 'nock';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// globalSetup runs in the main Vitest process before any test worker
+// spins up, so the `setupFiles` env loader hasn't fired yet. Load the
+// same env files here so DATABASE_URL / REDIS_* are available below.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../../.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test'), override: true });
 
 async function waitForPostgres(url: string, timeoutMs = 30000) {
   const { Client } = await import('pg');
@@ -40,7 +50,7 @@ export default async function globalSetup() {
   await waitForPostgres(process.env.DATABASE_URL!);
   await waitForRedis(process.env.REDIS_HOST!, Number(process.env.REDIS_PORT!), process.env.REDIS_PASSWORD!);
 
-  await execa('bun', ['x', 'prisma', 'db', 'push', '--accept-data-loss', '--skip-generate'], {
+  await execa('bun', ['x', 'prisma', 'db', 'push', '--accept-data-loss'], {
     env: { ...process.env, DATABASE_URL: process.env.DATABASE_URL },
     stdio: 'inherit',
   });

--- a/tests/integration/project-generator-queue-tests.test.ts
+++ b/tests/integration/project-generator-queue-tests.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { MonorepoGenerator } from '../../src/generators/monorepo.js';
+import { cloneInitConfig } from '../fixtures/configs/index.js';
+import { minimalConfig } from '../fixtures/configs/minimal.js';
+import type { InitConfig } from '../../src/types/index.js';
+
+/**
+ * Phase 4: queue component tests + the bullmq helper ship only for
+ * services where `backend.eventQueue === true`. The gate is kind-agnostic
+ * — auth and base services both ship the same worker template today.
+ */
+describe('MonorepoGenerator — queue tests gating', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stackr-queue-tests-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  async function generate(cfg: InitConfig): Promise<string> {
+    const projectDir = path.join(tempDir, cfg.projectName);
+    await new MonorepoGenerator(cfg).generate(projectDir);
+    return projectDir;
+  }
+
+  function coreBackend(projectDir: string): string {
+    return path.join(projectDir, 'core', 'backend');
+  }
+
+  function authBackend(projectDir: string): string {
+    return path.join(projectDir, 'auth', 'backend');
+  }
+
+  it('core/backend with eventQueue: true ships queue tests + bullmq helper', async () => {
+    const cfg = cloneInitConfig(minimalConfig);
+    const core = cfg.services.find((s) => s.name === 'core')!;
+    core.backend.eventQueue = true;
+
+    const projectDir = await generate(cfg);
+    const backend = coreBackend(projectDir);
+
+    expect(await fs.pathExists(path.join(backend, 'tests/component/queue/user-worker.test.ts'))).toBe(true);
+    expect(await fs.pathExists(path.join(backend, 'tests/helpers/bullmq.ts'))).toBe(true);
+  });
+
+  it('core/backend with eventQueue: false omits queue tests + bullmq helper', async () => {
+    const cfg = cloneInitConfig(minimalConfig);
+    const core = cfg.services.find((s) => s.name === 'core')!;
+    core.backend.eventQueue = false;
+
+    const projectDir = await generate(cfg);
+    const backend = coreBackend(projectDir);
+
+    expect(await fs.pathExists(path.join(backend, 'tests/component/queue'))).toBe(false);
+    expect(await fs.pathExists(path.join(backend, 'tests/helpers/bullmq.ts'))).toBe(false);
+  });
+
+  it('auth/backend with eventQueue: true ships queue tests + bullmq helper', async () => {
+    const cfg = cloneInitConfig(minimalConfig);
+    const auth = cfg.services.find((s) => s.kind === 'auth')!;
+    auth.backend.eventQueue = true;
+
+    const projectDir = await generate(cfg);
+    const backend = authBackend(projectDir);
+
+    expect(await fs.pathExists(path.join(backend, 'tests/component/queue/user-worker.test.ts'))).toBe(true);
+    expect(await fs.pathExists(path.join(backend, 'tests/helpers/bullmq.ts'))).toBe(true);
+  });
+
+  it('auth/backend with eventQueue: false omits queue tests + bullmq helper', async () => {
+    const cfg = cloneInitConfig(minimalConfig);
+    const auth = cfg.services.find((s) => s.kind === 'auth')!;
+    auth.backend.eventQueue = false;
+
+    const projectDir = await generate(cfg);
+    const backend = authBackend(projectDir);
+
+    expect(await fs.pathExists(path.join(backend, 'tests/component/queue'))).toBe(false);
+    expect(await fs.pathExists(path.join(backend, 'tests/helpers/bullmq.ts'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements [Phase 4 of the testing infrastructure rollout](plans/testing_infra/phase4_queue_tests.md). See also the [phased rollout README](plans/testing_infra/README.md).

Closes #69.

## Summary
- Queue component tests + `tests/helpers/bullmq.ts` helper ship only when `backend.eventQueue === true`. The gate is kind-agnostic — base and auth services share the same worker template, so they share the same tests.
- Four canonical BullMQ + Redis cases covered per Goldberg §7: ack on success, nack on failure, idempotency (jobId dedupe), batch partial failure.
- Fixed two pre-existing phase-3 issues that were blocking the end-to-end verification for the generated project's test harness.

## What's new
- `tests/helpers/bullmq.ts.ejs` (base + auth): singleton IORedis connection per Vitest worker process, `createTestQueue` / `createTestWorker` factories, and `waitForJob` / `waitForJobSettled` helpers that clean up listeners so the losing branch never dangles as an unhandled rejection.
- `tests/component/queue/user-worker.test.ts.ejs` (base + auth): the four canonical cases.
- Gating in `src/utils/template.ts::shouldIncludeFile`: `/tests/component/queue/` and `tests/helpers/bullmq.ts.ejs` both short-circuit when `ctx.backend.eventQueue` is false.
- Stackr integration test `tests/integration/project-generator-queue-tests.test.ts` covers `core × auth × eventQueue{true,false}`.

## Pre-existing phase-3 fixes pulled in along the way
Found while verifying the end-to-end flow:
- **`globalSetup` env loading.** `setupFiles` run inside each test worker — not in the main Vitest process where `globalSetup` runs — so `DATABASE_URL` / `REDIS_*` were undefined when `waitForPostgres` / `waitForRedis` / `prisma db push` ran. `globalSetup` now loads `.env` + `.env.test` itself. Applies to the prisma + drizzle variants on both base and auth.
- **`prisma db push --skip-generate`.** Flag was removed in Prisma 7; the command was silently printing the help text and returning exit 1. Dropped the flag.

## Test plan
- [x] `bun run build && bun run test` → 60 files / 540 tests pass (includes the 4 new queue-gating integration tests).
- [x] Generated a project with `eventQueue: true` on core, ran `bun run test tests/component/queue` against real Postgres + Redis (component profile) → 4/4 green in ~45 ms.
- [x] Full component suite on core backend: 7/7 green. Auth backend (`eventQueue: false`): 5/5 green and no queue tests emitted.
- [x] Sanity: regenerated a project with `eventQueue: false` on core → `tests/component/queue/` and `tests/helpers/bullmq.ts` both absent.