### PR TITLE
feat(cli): testing infra phase 5 — unit layer + monorepo-level E2E tests

### DIFF
--- a/src/commands/add-service.ts
+++ b/src/commands/add-service.ts
@@ -46,7 +46,9 @@ import {
   PortCollisionError,
 } from '../utils/port-allocator.js';
 import { validateServiceName, validateConfiguration } from '../utils/validation.js';
-import { renderTemplate } from '../utils/template.js';
+import { renderTemplate, shouldIncludeProjectFile, TEMPLATE_DIR } from '../utils/template.js';
+import { globby } from 'globby';
+import ejs from 'ejs';
 import { readStackrVersion } from '../utils/version.js';
 import semver from 'semver';
 
@@ -333,6 +335,14 @@ export async function runAddService(
       newConfig.pendingMigrations = [...(newConfig.pendingMigrations ?? []), pendingEntry];
     }
 
+    // Monorepo-level E2E regen. The tests/e2e subtree + root package.json
+    // + scripts/test-e2e.sh all iterate over `services`, so they go stale
+    // the moment a new service lands. Re-render every project-level file
+    // that's gated by `shouldIncludeProjectFile` and stage the results
+    // for Phase D. Untouched project-level files (setup.sh, README.md,
+    // etc.) are left alone — that's a pre-existing gap.
+    const plannedProjectE2E = await planProjectE2ERegen(root, newConfig);
+
     // =======================================================================
     // Phase C — dry-run validation
     // =======================================================================
@@ -406,6 +416,28 @@ export async function runAddService(
     if (plannedAuthFile) {
       await fs.ensureDir(path.dirname(plannedAuthFile.destPath));
       await fs.writeFile(plannedAuthFile.destPath, plannedAuthFile.contents, 'utf-8');
+    }
+
+    // 4b. Project-level e2e regen. Writes + deletes are both driven from
+    //     the Phase-B plan; no fresh decisions here.
+    for (const entry of plannedProjectE2E) {
+      if (entry.action === 'delete') {
+        await fs.remove(entry.destPath);
+        continue;
+      }
+      await fs.ensureDir(path.dirname(entry.destPath));
+      if (entry.isCopy) {
+        await fs.copy(entry.srcPath!, entry.destPath, { overwrite: true });
+      } else {
+        await fs.writeFile(entry.destPath, entry.contents!, 'utf-8');
+      }
+      if (entry.executable) {
+        try {
+          await fs.chmod(entry.destPath, 0o755);
+        } catch {
+          /* non-fatal */
+        }
+      }
     }
 
     // 5. Save stackr.config.json LAST so an interrupted run leaves the
@@ -1076,6 +1108,110 @@ function printNextSteps(args: {
     }
     console.log();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Project-level E2E regen
+// ---------------------------------------------------------------------------
+
+interface ProjectE2EPlanEntry {
+  destPath: string;
+  action: 'write' | 'delete';
+  contents?: string;
+  srcPath?: string;
+  isCopy?: boolean;
+  executable?: boolean;
+}
+
+/**
+ * Plan the rewrite of monorepo-level files under `templates/project/` whose
+ * contents depend on the current `services` list: the e2e test subtree,
+ * the e2e shell script, and the root `package.json`'s `test:e2e` script.
+ *
+ * Untouched project-level files (README, DESIGN, setup.sh, etc.) are a
+ * known gap — add-service does not refresh them. Scope is deliberately
+ * narrow: only files whose correctness depends on services[] AND whose
+ * staleness would make Phase 5 tests pointless are regenerated here.
+ */
+async function planProjectE2ERegen(
+  root: string,
+  newConfig: StackrConfigFile
+): Promise<ProjectE2EPlanEntry[]> {
+  const plan: ProjectE2EPlanEntry[] = [];
+  const rootCtx = buildProjectRootCtx(newConfig);
+
+  const e2eFiles = await globby('project/tests/e2e/**/*', {
+    cwd: TEMPLATE_DIR,
+    dot: true,
+    onlyFiles: true,
+    ignore: ['**/node_modules/**'],
+  });
+  const scriptFile = 'project/scripts/test-e2e.sh.ejs';
+  const pkgFile = 'project/package.json.ejs';
+  const managed = [...e2eFiles, scriptFile, pkgFile];
+
+  for (const file of managed) {
+    const absTemplatePath = path.join(TEMPLATE_DIR, file);
+    const rel = file.slice('project/'.length);
+    const destRel = rel.endsWith('.ejs') ? rel.slice(0, -4) : rel;
+    const destPath = path.join(root, destRel);
+
+    const included = shouldIncludeProjectFile(file, { services: newConfig.services });
+
+    if (!included) {
+      if (await fs.pathExists(destPath)) {
+        plan.push({ destPath, action: 'delete' });
+      }
+      continue;
+    }
+
+    if (!(await fs.pathExists(absTemplatePath))) {
+      continue;
+    }
+
+    if (file.endsWith('.ejs')) {
+      const content = await fs.readFile(absTemplatePath, 'utf-8');
+      const rendered = ejs.render(content, rootCtx);
+      plan.push({
+        destPath,
+        action: 'write',
+        contents: rendered,
+        executable: destRel === 'scripts/test-e2e.sh',
+      });
+    } else {
+      plan.push({
+        destPath,
+        action: 'write',
+        srcPath: absTemplatePath,
+        isCopy: true,
+      });
+    }
+  }
+
+  // If post-regen no service has tests, the e2e subtree should be absent.
+  // globby won't return a file that was already gated out by
+  // shouldIncludeProjectFile at a previous generation, so also sweep
+  // the on-disk e2e directory for stale contents.
+  const anyTests = newConfig.services.some((s) => s.backend.tests);
+  if (!anyTests) {
+    const e2eDir = path.join(root, 'tests/e2e');
+    if (await fs.pathExists(e2eDir)) {
+      plan.push({ destPath: e2eDir, action: 'delete' });
+    }
+  }
+
+  return plan;
+}
+
+function buildProjectRootCtx(cfg: StackrConfigFile): Record<string, unknown> {
+  return {
+    projectName: cfg.projectName,
+    packageManager: cfg.packageManager,
+    orm: cfg.orm,
+    aiTools: cfg.aiTools,
+    services: cfg.services,
+    stackrVersion: readStackrVersion(),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/generators/monorepo.ts
+++ b/src/generators/monorepo.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import chalk from 'chalk';
 import ejs from 'ejs';
 import { globby } from 'globby';
-import { TEMPLATE_DIR } from '../utils/template.js';
+import { TEMPLATE_DIR, shouldIncludeProjectFile } from '../utils/template.js';
 import { saveStackrConfig } from '../utils/config-file.js';
 import { initializeGit } from '../utils/git.js';
 import { cleanup } from '../utils/cleanup.js';
@@ -162,6 +162,10 @@ export class MonorepoGenerator {
       });
 
       for (const file of files) {
+        if (!shouldIncludeProjectFile(file, { services: this.initConfig.services })) {
+          continue;
+        }
+
         // Strip the `project/` prefix so the file lands at the
         // project root. Remove `.ejs` if present.
         let rel = file.slice(`${subtree}/`.length);
@@ -221,7 +225,7 @@ export class MonorepoGenerator {
   }
 
   private async makeScriptsExecutable(): Promise<void> {
-    const scriptNames = ['setup.sh', 'docker-dev.sh', 'docker-prod.sh'];
+    const scriptNames = ['setup.sh', 'docker-dev.sh', 'docker-prod.sh', 'test-e2e.sh'];
     for (const name of scriptNames) {
       const scriptPath = path.join(this.targetDir, 'scripts', name);
       try {

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -218,6 +218,49 @@ export function shouldIncludeFile(
 }
 
 /**
+ * Gate project-level (monorepo-root) templates rendered by
+ * `MonorepoGenerator.renderMonorepoRoot`. Unlike `shouldIncludeFile`, the
+ * context here is the monorepo-wide `services` list — per-service gating
+ * (ORM, platform, etc.) does not apply to files under `templates/project/`.
+ *
+ * `filePath` is relative to `TEMPLATE_DIR` and uses the OS path separator;
+ * this helper normalizes to forward slashes before matching so Windows
+ * generators hit the same gates.
+ */
+export function shouldIncludeProjectFile(
+  filePath: string,
+  ctx: { services: { kind: 'auth' | 'base'; backend: { tests: boolean; authMiddleware: string } }[] }
+): boolean {
+  const normalized = filePath.split(path.sep).join('/');
+
+  if (normalized.endsWith('.gitkeep')) return false;
+
+  const anyTests = ctx.services.some((s) => s.backend.tests);
+
+  // Monorepo-level e2e package — drop the whole subtree when no service
+  // opts into tests. Keeps --no-tests projects free of vitest config,
+  // axios clients, and the test-e2e wrapper.
+  if (normalized.includes('project/tests/e2e/') && !anyTests) return false;
+  if (normalized.endsWith('scripts/test-e2e.sh.ejs') && !anyTests) return false;
+
+  // cross-service-auth.test.ts requires an auth peer AND a base peer with
+  // tests enabled AND auth middleware active on that base. Without all
+  // three, the generated test cannot compile.
+  if (normalized.endsWith('cross-service-auth.test.ts.ejs')) {
+    const hasAuth = ctx.services.some((s) => s.kind === 'auth');
+    const hasGatedBase = ctx.services.some(
+      (s) =>
+        s.kind === 'base' &&
+        s.backend.tests &&
+        s.backend.authMiddleware !== 'none'
+    );
+    if (!(hasAuth && hasGatedBase)) return false;
+  }
+
+  return true;
+}
+
+/**
  * Check if a file is an EJS template
  */
 export function isTemplate(filePath: string): boolean {

--- a/templates/project/package.json.ejs
+++ b/templates/project/package.json.ejs
@@ -1,11 +1,15 @@
+<%
+  const scripts = { stackr: 'stackr' };
+  if (services.some((s) => s.backend.tests)) {
+    scripts['test:e2e'] = './scripts/test-e2e.sh';
+  }
+-%>
 {
   "name": "<%= projectName %>",
   "version": "0.1.0",
   "private": true,
   "description": "Monorepo scaffolded with create-stackr",
-  "scripts": {
-    "stackr": "stackr"
-  },
+  "scripts": <%- JSON.stringify(scripts, null, 2).replace(/\n/g, '\n  ') %>,
   "devDependencies": {
     "create-stackr": "^<%= stackrVersion %>"
   }

--- a/templates/project/scripts/test-e2e.sh.ejs
+++ b/templates/project/scripts/test-e2e.sh.ejs
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Brings up the `e2e` profile of docker-compose.test.yml, runs the
+# monorepo-level cross-service tests, and tears the stack down on CI.
+# Locally, the stack is left running so subsequent `bun run test:e2e`
+# iterations skip the cold docker-build.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "▶ Building and starting e2e profile..."
+docker compose -f docker-compose.test.yml --profile e2e up -d --build --wait
+
+cleanup() {
+  if [ -n "${CI:-}" ]; then
+    docker compose -f docker-compose.test.yml --profile e2e down
+  fi
+}
+trap cleanup EXIT
+
+(cd tests/e2e && <%= packageManager %> install && <%= packageManager %> run test)

--- a/templates/project/tests/e2e/cross-service-auth.test.ts.ejs
+++ b/templates/project/tests/e2e/cross-service-auth.test.ts.ejs
@@ -1,0 +1,40 @@
+<%
+  const authSvc = services.find(s => s.kind === 'auth');
+  const firstBase = services.find(s => s.kind === 'base' && s.backend.tests && s.backend.authMiddleware !== 'none');
+%>
+import { describe, it, expect, beforeAll } from 'vitest';
+import { waitForStack } from './helpers/wait-for-stack.js';
+import { extractSessionCookie } from './helpers/cookies.js';
+import { uniqueEmail, getShortUnique } from './helpers/unique.js';
+import { <%= authSvc.name %>Client, <%= firstBase.name %>Client } from './helpers/clients.js';
+
+describe('Cross-service auth contract', () => {
+  beforeAll(async () => { await waitForStack(); });
+
+  it('cookie issued by <%= authSvc.name %> is accepted by <%= firstBase.name %>', async () => {
+    // Arrange: real sign-up on the auth service.
+    const email = uniqueEmail('e2e');
+    const password = `pw-${getShortUnique(12)}`;
+    const signUp = await <%= authSvc.name %>Client.post('/api/auth/sign-up/email', {
+      email, password, name: 'E2E Test',
+    });
+    expect(signUp.status).toBeLessThan(400);
+    const cookie = extractSessionCookie(signUp.headers['set-cookie']);
+    expect(cookie).not.toBe('');
+
+    // Act: hit the gated /api/me route on the base service with the cookie.
+    // The base service's auth plugin forwards the cookie to the auth
+    // service's /api/auth/get-session and populates request.user on success.
+    const gated = await <%= firstBase.name %>Client.get('/api/me', {
+      headers: { cookie },
+    });
+
+    // Assert: forwarding succeeded and the session round-tripped with the right user.
+    expect(gated.status).toBe(200);
+    expect(gated.data.email).toBe(email);
+
+    // Negative control: same route without the cookie must 401.
+    const anon = await <%= firstBase.name %>Client.get('/api/me');
+    expect(anon.status).toBe(401);
+  });
+});

--- a/templates/project/tests/e2e/helpers/clients.ts.ejs
+++ b/templates/project/tests/e2e/helpers/clients.ts.ejs
@@ -1,0 +1,9 @@
+import axios from 'axios';
+<% services.filter(s => s.backend.tests).forEach(s => { %>
+export const <%= s.name %>Client = axios.create({
+  baseURL: 'http://127.0.0.1:<%= s.backend.port + 10000 %>',
+  timeout: 15_000,
+  validateStatus: () => true,
+  withCredentials: true,
+});
+<% }) %>

--- a/templates/project/tests/e2e/helpers/cookies.ts.ejs
+++ b/templates/project/tests/e2e/helpers/cookies.ts.ejs
@@ -1,0 +1,8 @@
+// Collapses a Set-Cookie header (string or string[]) into a single
+// `name=value; name=value` string suitable for use as a `Cookie:` request header.
+// BetterAuth may emit multiple cookies (session + csrf) per response — we keep all of them.
+export function extractSessionCookie(setCookie: string | string[] | undefined): string {
+  if (!setCookie) return '';
+  const arr = Array.isArray(setCookie) ? setCookie : [setCookie];
+  return arr.map((c) => c.split(';')[0]).join('; ');
+}

--- a/templates/project/tests/e2e/helpers/unique.ts.ejs
+++ b/templates/project/tests/e2e/helpers/unique.ts.ejs
@@ -1,0 +1,9 @@
+import { randomBytes } from 'crypto';
+
+export function getShortUnique(length = 6): string {
+  return randomBytes(Math.ceil(length / 2)).toString('hex').slice(0, length);
+}
+
+export function uniqueEmail(prefix = 'test'): string {
+  return `${prefix}-${getShortUnique()}@example.com`;
+}

--- a/templates/project/tests/e2e/helpers/wait-for-stack.ts.ejs
+++ b/templates/project/tests/e2e/helpers/wait-for-stack.ts.ejs
@@ -1,0 +1,21 @@
+<% services.filter(s => s.backend.tests).forEach(s => { %>
+import { <%= s.name %>Client } from './clients.js';
+<% }) %>
+
+export async function waitForStack(timeoutMs = 60_000): Promise<void> {
+  const clients = [
+<% services.filter(s => s.backend.tests).forEach(s => { %>    { name: '<%= s.name %>', client: <%= s.name %>Client },
+<% }) %>  ];
+  const deadline = Date.now() + timeoutMs;
+  for (const { name, client } of clients) {
+    let ready = false;
+    while (Date.now() < deadline) {
+      try {
+        const res = await client.get('/');
+        if (res.status === 200) { ready = true; break; }
+      } catch { /* retry */ }
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    if (!ready) throw new Error(`Service ${name} did not become ready within ${timeoutMs}ms`);
+  }
+}

--- a/templates/project/tests/e2e/package.json.ejs
+++ b/templates/project/tests/e2e/package.json.ejs
@@ -1,0 +1,15 @@
+{
+  "name": "<%= projectName %>-e2e-tests",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "~3.2.0",
+    "axios": "~1.7.0",
+    "typescript": "~5.8.3",
+    "@types/node": "~24.0.0"
+  }
+}

--- a/templates/project/tests/e2e/stack-smoke.test.ts.ejs
+++ b/templates/project/tests/e2e/stack-smoke.test.ts.ejs
@@ -1,0 +1,17 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { waitForStack } from './helpers/wait-for-stack.js';
+<% services.filter(s => s.backend.tests).forEach(s => { %>
+import { <%= s.name %>Client } from './helpers/clients.js';
+<% }) %>
+
+describe('Stack smoke — every service responds', () => {
+  beforeAll(async () => { await waitForStack(); });
+
+<% services.filter(s => s.backend.tests).forEach(s => { %>
+  it('<%= s.name %>: GET / → 200', async () => {
+    const res = await <%= s.name %>Client.get('/');
+    expect(res.status).toBe(200);
+    expect(res.data).toMatchObject({ service: '<%= s.name %>' });
+  });
+<% }) %>
+});

--- a/templates/project/tests/e2e/tsconfig.json.ejs
+++ b/templates/project/tests/e2e/tsconfig.json.ejs
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/templates/project/tests/e2e/vitest.config.ts.ejs
+++ b/templates/project/tests/e2e/vitest.config.ts.ejs
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.test.ts'],
+    testTimeout: 60000,
+    hookTimeout: 60000,
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+  },
+});

--- a/templates/services/auth/backend/tests/unit/utils/errors.test.ts.ejs
+++ b/templates/services/auth/backend/tests/unit/utils/errors.test.ts.ejs
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { AppError, ErrorCode, ErrorFactory, normalizeError } from '../../../utils/errors.js';
+
+describe('ErrorFactory', () => {
+  it('resourceNotFound produces a 404 AppError with the resource in the message', () => {
+    const err = ErrorFactory.resourceNotFound('user');
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(404);
+    expect(err.code).toBe(ErrorCode.RESOURCE_NOT_FOUND);
+    expect(err.message).toContain('user');
+  });
+
+  it('userAlreadyExists produces a 409 AppError', () => {
+    const err = ErrorFactory.userAlreadyExists();
+    expect(err.statusCode).toBe(409);
+    expect(err.code).toBe(ErrorCode.USER_ALREADY_EXISTS);
+  });
+
+  it('unauthorized produces a 401 AppError and serializes to a typed API response', () => {
+    const err = ErrorFactory.unauthorized();
+    expect(err.statusCode).toBe(401);
+    const api = err.toApiResponse('req_1', '/x');
+    expect(api.error.code).toBe(ErrorCode.AUTH_UNAUTHORIZED);
+    expect(api.error.requestId).toBe('req_1');
+    expect(api.error.path).toBe('/x');
+  });
+});
+
+describe('normalizeError', () => {
+  it('passes AppError through untouched', () => {
+    const original = ErrorFactory.unauthorized();
+    expect(normalizeError(original)).toBe(original);
+  });
+
+  it('wraps a plain Error as an internal-server AppError', () => {
+    const wrapped = normalizeError(new Error('boom'));
+    expect(wrapped).toBeInstanceOf(AppError);
+    expect(wrapped.statusCode).toBe(500);
+    expect(wrapped.code).toBe(ErrorCode.INTERNAL_SERVER_ERROR);
+  });
+});

--- a/templates/services/base/backend/controllers/rest-api/server.ts.ejs
+++ b/templates/services/base/backend/controllers/rest-api/server.ts.ejs
@@ -63,7 +63,21 @@ export async function buildServer(overrides: FastifyServerOptions = {}): Promise
       version: "1.0.0"
     });
   });
-
+<% if (service.backend.authMiddleware !== 'none') { %>
+  // Gated echo endpoint. The auth plugin's requireAuth preHandler forwards
+  // the incoming cookie to the auth service's /api/auth/get-session and
+  // either short-circuits with a 401 or populates request.user. Used by
+  // the monorepo-level cross-service-auth E2E to verify that cookie
+  // forwarding reaches the auth service end-to-end.
+  server.get(
+    "/api/me",
+    { preHandler: [server.requireAuth] },
+    async (request) => {
+      const { user } = request as import("fastify").AuthFastifyRequest;
+      return { id: user.id, email: user.email };
+    }
+  );
+<% } %>
   await server.ready();
   return server;
 }

--- a/templates/services/base/backend/tests/unit/utils/errors.test.ts.ejs
+++ b/templates/services/base/backend/tests/unit/utils/errors.test.ts.ejs
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { AppError, ErrorCode, ErrorFactory, normalizeError } from '../../../utils/errors.js';
+
+describe('ErrorFactory', () => {
+  it('resourceNotFound produces a 404 AppError with the resource in the message', () => {
+    const err = ErrorFactory.resourceNotFound('user');
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(404);
+    expect(err.code).toBe(ErrorCode.RESOURCE_NOT_FOUND);
+    expect(err.message).toContain('user');
+  });
+
+  it('userAlreadyExists produces a 409 AppError', () => {
+    const err = ErrorFactory.userAlreadyExists();
+    expect(err.statusCode).toBe(409);
+    expect(err.code).toBe(ErrorCode.USER_ALREADY_EXISTS);
+  });
+
+  it('unauthorized produces a 401 AppError and serializes to a typed API response', () => {
+    const err = ErrorFactory.unauthorized();
+    expect(err.statusCode).toBe(401);
+    const api = err.toApiResponse('req_1', '/x');
+    expect(api.error.code).toBe(ErrorCode.AUTH_UNAUTHORIZED);
+    expect(api.error.requestId).toBe('req_1');
+    expect(api.error.path).toBe('/x');
+  });
+});
+
+describe('normalizeError', () => {
+  it('passes AppError through untouched', () => {
+    const original = ErrorFactory.unauthorized();
+    expect(normalizeError(original)).toBe(original);
+  });
+
+  it('wraps a plain Error as an internal-server AppError', () => {
+    const wrapped = normalizeError(new Error('boom'));
+    expect(wrapped).toBeInstanceOf(AppError);
+    expect(wrapped.statusCode).toBe(500);
+    expect(wrapped.code).toBe(ErrorCode.INTERNAL_SERVER_ERROR);
+  });
+});

--- a/tests/integration/add-service-e2e-client.test.ts
+++ b/tests/integration/add-service-e2e-client.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import { runAddService } from '../../src/commands/add-service.js';
+import { createAddServiceFixture, type AddServiceFixture } from './add-service-helpers.js';
+
+/**
+ * Phase 5: `stackr add service` must refresh the monorepo-level e2e
+ * artifacts so the new service appears (or doesn't) in the test
+ * harness. Without this, e2e tests go stale the moment you add a
+ * service, defeating the purpose of the scaffold.
+ */
+describe('stackr add service — monorepo-level e2e regen', () => {
+  let fx: AddServiceFixture;
+
+  afterEach(async () => {
+    await fx?.cleanup();
+  });
+
+  it('tests: true → new service appears in clients.ts + stack-smoke.test.ts + test:e2e stays', async () => {
+    fx = await createAddServiceFixture('add-e2e-new');
+    await runAddService('scout', { install: false });
+
+    const clients = await fs.readFile(
+      path.join(fx.projectDir, 'tests/e2e/helpers/clients.ts'),
+      'utf-8'
+    );
+    const smoke = await fs.readFile(
+      path.join(fx.projectDir, 'tests/e2e/stack-smoke.test.ts'),
+      'utf-8'
+    );
+    const waitFor = await fs.readFile(
+      path.join(fx.projectDir, 'tests/e2e/helpers/wait-for-stack.ts'),
+      'utf-8'
+    );
+
+    expect(clients).toContain('scoutClient');
+    expect(clients).toContain('18080'); // first free base port after core=8080 → 18080 with +10000
+    expect(smoke).toContain('scoutClient');
+    expect(smoke).toContain("'scout: GET / → 200'");
+    expect(waitFor).toContain('scoutClient');
+
+    // Pre-existing services still render.
+    expect(clients).toContain('coreClient');
+    expect(clients).toContain('authClient');
+
+    const pkg = JSON.parse(
+      await fs.readFile(path.join(fx.projectDir, 'package.json'), 'utf-8')
+    );
+    expect(pkg.scripts['test:e2e']).toBe('./scripts/test-e2e.sh');
+  });
+
+  it('tests: false → new service is absent from clients.ts + stack-smoke.test.ts', async () => {
+    fx = await createAddServiceFixture('add-e2e-notests');
+    await runAddService('scout', { install: false, tests: false });
+
+    const clients = await fs.readFile(
+      path.join(fx.projectDir, 'tests/e2e/helpers/clients.ts'),
+      'utf-8'
+    );
+    const smoke = await fs.readFile(
+      path.join(fx.projectDir, 'tests/e2e/stack-smoke.test.ts'),
+      'utf-8'
+    );
+
+    expect(clients).not.toContain('scoutClient');
+    expect(smoke).not.toContain('scoutClient');
+    // Pre-existing services still render.
+    expect(clients).toContain('coreClient');
+    expect(clients).toContain('authClient');
+  });
+});

--- a/tests/integration/compose-port-no-overlap.test.ts
+++ b/tests/integration/compose-port-no-overlap.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import YAML from 'yaml';
+import { MonorepoGenerator } from '../../src/generators/monorepo.js';
+import { PRESETS, loadPreset } from '../../src/config/presets.js';
+import { applyCliOptionsToPreset } from '../../src/prompts/index.js';
+import type { InitConfig } from '../../src/types/index.js';
+
+/**
+ * Phase 5 regression guard: dev compose and the e2e profile of the test
+ * compose must be able to run concurrently, which requires their host
+ * port sets to be fully disjoint. The `+10000` offset enforces this
+ * today; this test fails loudly if a future service type (or a typo in
+ * the generator) lands a test port back in the dev range.
+ */
+describe('dev vs e2e profile — host port disjointness', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stackr-port-overlap-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  function collectHostPorts(composeYaml: string, profileFilter?: string): Set<number> {
+    const parsed = YAML.parse(composeYaml) as {
+      services?: Record<string, { ports?: unknown[]; profiles?: string[] }>;
+    };
+    const out = new Set<number>();
+    if (!parsed.services) return out;
+    for (const [, svc] of Object.entries(parsed.services)) {
+      if (profileFilter) {
+        const profiles = svc.profiles ?? [];
+        if (!profiles.includes(profileFilter)) continue;
+      }
+      if (!Array.isArray(svc.ports)) continue;
+      for (const spec of svc.ports) {
+        // Port specs are usually "127.0.0.1:HOST:CONTAINER" strings; accept
+        // objects too for future-compat.
+        if (typeof spec === 'string') {
+          const match = spec.match(/(?:^|:)(\d+):\d+(?:\/|$)/);
+          if (match) out.add(Number(match[1]));
+        } else if (spec && typeof spec === 'object' && 'published' in spec) {
+          const published = (spec as { published: number | string }).published;
+          out.add(typeof published === 'string' ? Number(published) : published);
+        }
+      }
+    }
+    return out;
+  }
+
+  it.each(PRESETS.map((p) => [p.name] as const))(
+    '%s preset → dev ∩ e2e host ports is empty',
+    async (presetName) => {
+      const body = loadPreset(presetName);
+      const config: InitConfig = applyCliOptionsToPreset(
+        body,
+        `port-overlap-${presetName.toLowerCase()}`,
+        'npm',
+        {}
+      );
+      const projectDir = path.join(tempDir, config.projectName);
+      await new MonorepoGenerator(config).generate(projectDir);
+
+      const devYaml = await fs.readFile(
+        path.join(projectDir, 'docker-compose.yml'),
+        'utf-8'
+      );
+      const testYaml = await fs.readFile(
+        path.join(projectDir, 'docker-compose.test.yml'),
+        'utf-8'
+      );
+
+      const devPorts = collectHostPorts(devYaml);
+      // Test compose services belong to either the `component` or `e2e`
+      // profile. The e2e profile is the one that runs alongside dev; it
+      // is the strictest disjointness requirement.
+      const e2ePorts = new Set<number>([
+        ...collectHostPorts(testYaml, 'component'),
+        ...collectHostPorts(testYaml, 'e2e'),
+      ]);
+
+      expect(devPorts.size, 'dev compose must expose at least one host port').toBeGreaterThan(0);
+      expect(e2ePorts.size, 'e2e profile must expose at least one host port').toBeGreaterThan(0);
+
+      const intersection = [...devPorts].filter((p) => e2ePorts.has(p));
+      expect(intersection, 'dev and e2e profiles must not share host ports').toEqual([]);
+    }
+  );
+});

--- a/tests/integration/e2e-client-ports.test.ts
+++ b/tests/integration/e2e-client-ports.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { MonorepoGenerator } from '../../src/generators/monorepo.js';
+import { PRESETS, loadPreset } from '../../src/config/presets.js';
+import { applyCliOptionsToPreset } from '../../src/prompts/index.js';
+import { TEST_PORT_OFFSET } from '../../src/utils/port-allocator.js';
+import type { InitConfig } from '../../src/types/index.js';
+
+/**
+ * Phase 5: every axios client in `tests/e2e/helpers/clients.ts` must
+ * point at its service's app container on the `+10000` test-compose
+ * port. A drift here would silently break cross-service tests without
+ * the test runner ever talking to the e2e stack.
+ */
+describe('tests/e2e/helpers/clients.ts — baseURL alignment', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stackr-e2e-ports-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  describe.each(PRESETS.map((p) => [p.name] as const))('%s preset', (presetName) => {
+    it('each <service>Client uses dev port + TEST_PORT_OFFSET', async () => {
+      const body = loadPreset(presetName);
+      const config: InitConfig = applyCliOptionsToPreset(
+        body,
+        `e2e-ports-${presetName.toLowerCase()}`,
+        'npm',
+        {}
+      );
+      const projectDir = path.join(tempDir, config.projectName);
+      await new MonorepoGenerator(config).generate(projectDir);
+
+      const clientsSrc = await fs.readFile(
+        path.join(projectDir, 'tests/e2e/helpers/clients.ts'),
+        'utf-8'
+      );
+
+      for (const svc of config.services.filter((s) => s.backend.tests)) {
+        const expectedPort = svc.backend.port + TEST_PORT_OFFSET;
+        const pattern = new RegExp(
+          `export const ${svc.name}Client[\\s\\S]*?baseURL:\\s*'http:\\/\\/127\\.0\\.0\\.1:${expectedPort}'`
+        );
+        expect(
+          pattern.test(clientsSrc),
+          `${svc.name}Client should target http://127.0.0.1:${expectedPort} — got:\n${clientsSrc}`
+        ).toBe(true);
+      }
+    });
+  });
+});

--- a/tests/integration/project-generator-e2e-scaffold.test.ts
+++ b/tests/integration/project-generator-e2e-scaffold.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { MonorepoGenerator } from '../../src/generators/monorepo.js';
+import { PRESETS, loadPreset } from '../../src/config/presets.js';
+import { applyCliOptionsToPreset } from '../../src/prompts/index.js';
+import type { InitConfig } from '../../src/types/index.js';
+
+/**
+ * Phase 5: the monorepo-level `<project>/tests/e2e/` package, the
+ * `scripts/test-e2e.sh` wrapper, and the `test:e2e` script in the root
+ * `package.json` all ship whenever at least one service opts into tests.
+ * cross-service-auth.test.ts is an additional gate: auth peer + a base
+ * service with tests enabled + non-`none` authMiddleware.
+ */
+describe('MonorepoGenerator — monorepo-level e2e scaffold', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stackr-e2e-scaffold-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  describe.each(PRESETS.map((p) => [p.name] as const))('%s preset', (presetName) => {
+    async function generate(): Promise<{ projectDir: string; config: InitConfig }> {
+      const body = loadPreset(presetName);
+      const config: InitConfig = applyCliOptionsToPreset(
+        body,
+        `e2e-${presetName.toLowerCase()}`,
+        'npm',
+        {}
+      );
+      const projectDir = path.join(tempDir, config.projectName);
+      await new MonorepoGenerator(config).generate(projectDir);
+      return { projectDir, config };
+    }
+
+    it('tests/e2e package + scripts/test-e2e.sh + root test:e2e all land on disk', async () => {
+      const { projectDir, config } = await generate();
+      const hasTests = config.services.some((s) => s.backend.tests);
+      expect(hasTests).toBe(true); // default preset state
+
+      const e2eDir = path.join(projectDir, 'tests/e2e');
+      expect(await fs.pathExists(path.join(e2eDir, 'package.json'))).toBe(true);
+      expect(await fs.pathExists(path.join(e2eDir, 'tsconfig.json'))).toBe(true);
+      expect(await fs.pathExists(path.join(e2eDir, 'vitest.config.ts'))).toBe(true);
+      expect(await fs.pathExists(path.join(e2eDir, 'helpers/clients.ts'))).toBe(true);
+      expect(await fs.pathExists(path.join(e2eDir, 'helpers/wait-for-stack.ts'))).toBe(true);
+      expect(await fs.pathExists(path.join(e2eDir, 'helpers/cookies.ts'))).toBe(true);
+      expect(await fs.pathExists(path.join(e2eDir, 'helpers/unique.ts'))).toBe(true);
+      expect(await fs.pathExists(path.join(e2eDir, 'stack-smoke.test.ts'))).toBe(true);
+
+      // cross-service-auth is gated on auth + base-with-tests + non-'none' mw.
+      const hasAuth = config.services.some((s) => s.kind === 'auth');
+      const hasGatedBase = config.services.some(
+        (s) => s.kind === 'base' && s.backend.tests && s.backend.authMiddleware !== 'none'
+      );
+      const crossSvcAuth = path.join(e2eDir, 'cross-service-auth.test.ts');
+      if (hasAuth && hasGatedBase) {
+        expect(await fs.pathExists(crossSvcAuth)).toBe(true);
+      } else {
+        expect(await fs.pathExists(crossSvcAuth)).toBe(false);
+      }
+
+      const scriptPath = path.join(projectDir, 'scripts/test-e2e.sh');
+      expect(await fs.pathExists(scriptPath)).toBe(true);
+      const stat = await fs.stat(scriptPath);
+      // Owner-exec bit set.
+      expect((stat.mode & 0o100) !== 0).toBe(true);
+
+      const pkg = JSON.parse(
+        await fs.readFile(path.join(projectDir, 'package.json'), 'utf-8')
+      );
+      expect(pkg.scripts['test:e2e']).toBe('./scripts/test-e2e.sh');
+    });
+
+    it('e2e package.json declares vitest + axios devDeps', async () => {
+      const { projectDir } = await generate();
+      const pkg = JSON.parse(
+        await fs.readFile(path.join(projectDir, 'tests/e2e/package.json'), 'utf-8')
+      );
+      expect(pkg.devDependencies.vitest).toBeDefined();
+      expect(pkg.devDependencies.axios).toBeDefined();
+      expect(pkg.scripts.test).toBe('vitest run');
+    });
+  });
+
+  it('--no-tests preset → no tests/e2e, no test-e2e.sh, no test:e2e script', async () => {
+    const body = loadPreset('minimal');
+    const config: InitConfig = applyCliOptionsToPreset(
+      body,
+      'e2e-notests',
+      'npm',
+      { tests: false }
+    );
+    // Safety check — applyCliOptionsToPreset should have flipped every
+    // service.backend.tests to false.
+    expect(config.services.every((s) => !s.backend.tests)).toBe(true);
+
+    const projectDir = path.join(tempDir, config.projectName);
+    await new MonorepoGenerator(config).generate(projectDir);
+
+    expect(await fs.pathExists(path.join(projectDir, 'tests/e2e'))).toBe(false);
+    expect(await fs.pathExists(path.join(projectDir, 'scripts/test-e2e.sh'))).toBe(false);
+
+    const pkg = JSON.parse(
+      await fs.readFile(path.join(projectDir, 'package.json'), 'utf-8')
+    );
+    expect(pkg.scripts['test:e2e']).toBeUndefined();
+  });
+});

--- a/tests/integration/project-generator-unit-scaffold.test.ts
+++ b/tests/integration/project-generator-unit-scaffold.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { MonorepoGenerator } from '../../src/generators/monorepo.js';
+import { PRESETS, loadPreset } from '../../src/config/presets.js';
+import { applyCliOptionsToPreset } from '../../src/prompts/index.js';
+import type { InitConfig } from '../../src/types/index.js';
+
+/**
+ * Phase 5 Part C: per-service `tests/unit/` is deliberately minimal —
+ * exactly one `errors.test.ts` per tests-enabled backend, and no
+ * regression into trivial-helper tests that would just add noise.
+ */
+describe('MonorepoGenerator — unit/ scaffold', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stackr-unit-scaffold-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  describe.each(PRESETS.map((p) => [p.name] as const))('%s preset', (presetName) => {
+    async function generate(): Promise<{ projectDir: string; config: InitConfig }> {
+      const body = loadPreset(presetName);
+      const config: InitConfig = applyCliOptionsToPreset(
+        body,
+        `unit-${presetName.toLowerCase()}`,
+        'npm',
+        {}
+      );
+      const projectDir = path.join(tempDir, config.projectName);
+      await new MonorepoGenerator(config).generate(projectDir);
+      return { projectDir, config };
+    }
+
+    it('tests-enabled backends ship tests/unit/utils/errors.test.ts — and nothing else', async () => {
+      const { projectDir, config } = await generate();
+
+      for (const svc of config.services.filter((s) => s.backend.tests)) {
+        const backend = path.join(projectDir, svc.name, 'backend');
+        expect(
+          await fs.pathExists(path.join(backend, 'tests/unit/utils/errors.test.ts')),
+          `${svc.name} errors.test.ts`
+        ).toBe(true);
+
+        // Explicit negative — prevent regression into cut tests.
+        expect(
+          await fs.pathExists(path.join(backend, 'tests/unit/helpers/unique.test.ts')),
+          `${svc.name} unique.test.ts should NOT exist`
+        ).toBe(false);
+      }
+    });
+  });
+
+  it('--no-tests backend has no tests/unit at all', async () => {
+    const body = loadPreset('minimal');
+    const config: InitConfig = applyCliOptionsToPreset(
+      body,
+      'unit-notests',
+      'npm',
+      { tests: false }
+    );
+    const projectDir = path.join(tempDir, config.projectName);
+    await new MonorepoGenerator(config).generate(projectDir);
+
+    for (const svc of config.services) {
+      expect(
+        await fs.pathExists(path.join(projectDir, svc.name, 'backend/tests/unit'))
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Closes #71. See [plans/testing_infra/phase5_unit_and_e2e.md](plans/testing_infra/phase5_unit_and_e2e.md) and the [phased rollout README](plans/testing_infra/README.md).

## Summary
- Monorepo-level `<project>/tests/e2e/` package: `package.json`, `tsconfig.json`, `vitest.config.ts`, `helpers/{clients,wait-for-stack,cookies,unique}.ts`, `stack-smoke.test.ts`, and `cross-service-auth.test.ts` (gated on auth + base-with-tests + non-`none` authMiddleware).
- Per-service `tests/unit/utils/errors.test.ts` (base + auth) — deliberately thin smoke layer, no trivial-helper tests.
- Gated `/api/me` echo route on base backends so the cross-service-auth test can exercise the cookie-forwarding contract end-to-end (preHandler: `server.requireAuth`).
- `scripts/test-e2e.sh` wrapper (e2e profile up --wait, run vitest, teardown on CI) + root `package.json` `test:e2e` script, conditional on any service having tests.
- `stackr add service` now re-renders project-level e2e artifacts so the new service lands in `clients.ts` / `stack-smoke.test.ts` / `wait-for-stack.ts` (or is absent under `--no-tests`); `test-e2e.sh` is chmod'd alongside the other scripts. A new `shouldIncludeProjectFile` helper centralizes the project-level gates.

## New stackr tests
- `project-generator-e2e-scaffold.test.ts` — preset × scaffold presence + chmod + root `test:e2e` + `--no-tests` negative.
- `project-generator-unit-scaffold.test.ts` — `errors.test.ts` presence + negative assertion against `unique.test.ts`.
- `e2e-client-ports.test.ts` — every axios baseURL is `dev port + TEST_PORT_OFFSET`.
- `add-service-e2e-client.test.ts` — new service appears (or not) in the e2e harness after `stackr add service`.
- `compose-port-no-overlap.test.ts` — dev compose and e2e profile host-port sets are disjoint (regression guard for the `+10000` offset).

## Test plan
- [x] `bun run build` clean
- [x] `bun run test` — 65 files / 559 tests pass (added 19 tests across 5 new files)
- [x] Fresh `--defaults` generation inspected: `/api/me` emitted on `core`, `tests/e2e/{clients,stack-smoke,cross-service-auth}.ts` render cleanly, `scripts/test-e2e.sh` chmod 0755, root `package.json` has `test:e2e`.
- [x] `--no-tests` generation: no `tests/e2e/`, no `scripts/test-e2e.sh`, no `test:e2e` script.
- [ ] End-to-end `bun run test:e2e` against real Docker — out of scope for CI; verified locally by generating a fresh project and reading the rendered tests compile against the real stack. Phase 5 plan's live Docker run is a follow-up.

## Notes
- `setup.sh` still does not regenerate on `stackr add service` — pre-existing gap, out of scope.
- The cross-service-auth test's negative `GET /api/me` (no cookie) probes the gated route's 401 path via the auth plugin — guards against `/api/me` accidentally becoming public.