### PR TITLE
fix(templates): prevent Next.js 16 cache footguns (updateTag + React.cache getSession)

### DIFF
--- a/templates/features/web/auth/app/(protected)/dashboard/page.tsx.ejs
+++ b/templates/features/web/auth/app/(protected)/dashboard/page.tsx.ejs
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { getSession } from "@/lib/auth/actions";
+import { getSession } from "@/lib/auth/session";
 import { DashboardClient } from "./dashboard-client";
 
 export default async function DashboardPage() {

--- a/templates/features/web/auth/app/(protected)/layout.tsx.ejs
+++ b/templates/features/web/auth/app/(protected)/layout.tsx.ejs
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { getSession } from "@/lib/auth/actions";
+import { getSession } from "@/lib/auth/session";
 import { ThemeToggle } from "@/components/theme-toggle";
 
 export default async function ProtectedLayout({ children }: { children: React.ReactNode }) {

--- a/templates/features/web/auth/app/(protected)/settings/security/page.tsx.ejs
+++ b/templates/features/web/auth/app/(protected)/settings/security/page.tsx.ejs
@@ -1,4 +1,4 @@
-import { getSession } from "@/lib/auth/actions";
+import { getSession } from "@/lib/auth/session";
 import { SecuritySettings } from "./security-settings";
 
 export default async function SecurityPage() {

--- a/templates/features/web/auth/app/(protected)/settings/sessions/page.tsx.ejs
+++ b/templates/features/web/auth/app/(protected)/settings/sessions/page.tsx.ejs
@@ -1,4 +1,4 @@
-import { getSession } from "@/lib/auth/actions";
+import { getSession } from "@/lib/auth/session";
 import { listSessions } from "@/lib/auth/sessions";
 import { SessionsClient } from "./sessions-client";
 

--- a/templates/services/auth/web/src/app/(dashboard)/layout.tsx
+++ b/templates/services/auth/web/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { getSession } from "@/lib/auth/actions";
+import { getSession } from "@/lib/auth/session";
 import { DashboardSidebar } from "@/components/dashboard-sidebar";
 
 export default async function DashboardLayout({

--- a/templates/services/auth/web/src/app/(dashboard)/users/[id]/page.tsx
+++ b/templates/services/auth/web/src/app/(dashboard)/users/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { fetchUser } from "@/lib/admin/actions";
-import { getSession } from "@/lib/auth/actions";
+import { getSession } from "@/lib/auth/session";
 import { UserDetailClient } from "./user-detail-client";
 
 export default async function UserDetailPage({
@@ -9,6 +9,8 @@ export default async function UserDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  // getSession() is also called in (dashboard)/layout.tsx; React.cache() in
+  // session.ts dedupes them into one backend fetch per request.
   const [user, session] = await Promise.all([fetchUser(id), getSession()]);
 
   if (!user) notFound();

--- a/templates/services/auth/web/src/lib/admin/actions.ts
+++ b/templates/services/auth/web/src/lib/admin/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { buildAuthHeaders } from "@/lib/auth/cookies";
 import { AUTH_CONFIG } from "@/lib/auth/config";
 import type { User, UserRole } from "@/lib/auth/types";
@@ -75,7 +75,7 @@ export async function updateUserRole(
     };
   }
 
-  revalidateTag("admin-users");
+  updateTag("admin-users");
   return { success: true };
 }
 
@@ -95,6 +95,6 @@ export async function deleteUser(
     };
   }
 
-  revalidateTag("admin-users");
+  updateTag("admin-users");
   return { success: true };
 }

--- a/templates/services/auth/web/src/lib/auth/actions.ts
+++ b/templates/services/auth/web/src/lib/auth/actions.ts
@@ -6,8 +6,9 @@ import {
   clearSessionCookie,
   buildAuthHeaders,
 } from "./cookies";
+import { getSession } from "./session";
 import { AUTH_CONFIG, BETTER_AUTH_COOKIE_NAME } from "./config";
-import type { AuthSession, FormActionState } from "./types";
+import type { FormActionState } from "./types";
 
 function extractSessionToken(response: Response): string | null {
   const setCookieHeaders = response.headers.getSetCookie();
@@ -68,28 +69,6 @@ export async function signOut(): Promise<void> {
   }
   await clearSessionCookie();
   redirect("/login");
-}
-
-export async function getSession(): Promise<AuthSession | null> {
-  try {
-    const response = await fetch(
-      `${AUTH_CONFIG.backendUrl}/api/auth/get-session`,
-      {
-        method: "GET",
-        headers: await buildAuthHeaders(),
-        cache: "no-store",
-      }
-    );
-
-    if (!response.ok) return null;
-
-    const data = await response.json();
-    if (!data?.user) return null;
-
-    return data as AuthSession;
-  } catch {
-    return null;
-  }
 }
 
 export async function loginAction(

--- a/templates/services/auth/web/src/lib/auth/session.ts
+++ b/templates/services/auth/web/src/lib/auth/session.ts
@@ -1,0 +1,32 @@
+import "server-only";
+import { cache } from "react";
+import { buildAuthHeaders } from "./cookies";
+import { AUTH_CONFIG } from "./config";
+import type { AuthSession } from "./types";
+
+// Wrapped in React.cache() so a layout + its nested pages share one backend
+// call per request. `cache: "no-store"` alone only opts out of the data cache;
+// it does NOT dedupe within a request. Keep this file out of "use server" —
+// every export in a Server Action file becomes a callable action, which would
+// defeat the per-request memoization.
+export const getSession = cache(async (): Promise<AuthSession | null> => {
+  try {
+    const response = await fetch(
+      `${AUTH_CONFIG.backendUrl}/api/auth/get-session`,
+      {
+        method: "GET",
+        headers: await buildAuthHeaders(),
+        cache: "no-store",
+      }
+    );
+
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    if (!data?.user) return null;
+
+    return data as AuthSession;
+  } catch {
+    return null;
+  }
+});

--- a/templates/services/base/web/DESIGN.md.ejs
+++ b/templates/services/base/web/DESIGN.md.ejs
@@ -58,7 +58,7 @@ Pages requiring authentication:
 <% } %>
 - `/settings/sessions` - Active session management
 
-Protected by `(protected)/layout.tsx` which calls `getSession()` and redirects unauthenticated users.
+Protected by `(protected)/layout.tsx` which calls `getSession()` and redirects unauthenticated users. `getSession()` is wrapped in `React.cache()`, so when nested pages also call it the layout + page share a single backend round-trip per request.
 
 ### `auth/` - API-style Routes (Route Handlers)
 
@@ -77,9 +77,9 @@ Non-UI routes that handle redirects and callbacks:
 
 ### Session Management
 
-1. **Server Components**: Read session from cookies via `getSession()` server action
+1. **Server Components**: Read session via the request-scoped `getSession()` helper from `@/lib/auth/session` (wrapped in `React.cache()`). NOT a Server Action — every export of a `'use server'` file becomes a callable action over RPC, which would defeat the per-request memoization.
 2. **Protected Layouts**: Redirect unauthenticated users server-side
-3. **Server Actions**: Handle sign-in/sign-out with cookie management
+3. **Server Actions** (`@/lib/auth/actions`): Handle sign-in/sign-out and form submissions with cookie management — every export here is `'use server'`-marked and callable from client components.
 4. **Form Components**: Use `useActionState` and `useFormStatus` for pending/error states
 
 ### Cookie-Based Auth
@@ -134,7 +134,10 @@ Browser                    Next.js                    Fastify Backend
 **Server actions + revalidation** for server data (auth, CRUD):
 - `useActionState` for form submissions with pending/error state
 - `useFormStatus` for submit button loading states
-- `revalidatePath`/`revalidateTag` to refresh server data after mutations
+- `updateTag(tag)` for read-your-own-writes mutations — the idiomatic Next 16 call: refreshes tagged caches *in the same request* so the redirect or re-render that follows sees fresh data
+- `revalidateTag(tag)` for background invalidation when the caller does not need the new data immediately (stale-while-revalidate)
+- `revalidatePath(path)` when the route is not tagged
+- **Avoid `revalidateTag(tag, 'max')`**: with `cacheLife('max')` the path is *not* marked revalidated — the runtime treats the call as a stale-while-revalidate hint, so the current request keeps serving stale data. Use `updateTag(tag)` instead.
 - No client-side cache duplication of server state
 
 **Zustand stores** only for client-side global state:

--- a/templates/services/base/web/src/lib/BEST_PRACTICES.md.ejs
+++ b/templates/services/base/web/src/lib/BEST_PRACTICES.md.ejs
@@ -9,14 +9,15 @@ Guidelines for utility functions and configuration in the `lib/` directory.
 lib/
 <% if (features.authentication.enabled) { %>
 ├── auth/           # Authentication utilities
-│   ├── actions.ts     # Server actions for auth operations
+│   ├── actions.ts     # Server actions: sign-in, sign-out, form actions ('use server')
+│   ├── session.ts     # Request-scoped getSession() helper (React.cache()) — NOT 'use server'
 │   ├── config.ts      # Auth configuration and constants
 │   ├── cookies.ts     # Cookie read/write utilities
 <% if (hasOAuth) { %>
 │   ├── oauth.ts       # OAuth flow helpers
 │   ├── pkce.ts        # PKCE code generation
 <% } %>
-│   ├── sessions.ts    # Session validation
+│   ├── sessions.ts    # List / revoke active sessions
 │   └── user-agent.ts  # Device detection
 <% } %>
 <% if (features.sessionManagement) { %>
@@ -32,21 +33,27 @@ lib/
 
 ### Server-Only Code
 
-Functions that should only run on the server:
+Functions that should only run on the server. Wrap reads that may be called from multiple Server Components in the same request (layout + page) with `React.cache()` so they share one fetch:
 
-```tsx
 <% if (features.authentication.enabled) { %>
-// lib/auth/sessions.ts
-import "server-only";  // Build error if imported client-side
-import { cookies } from "next/headers";
+```tsx
+// lib/auth/session.ts
+import "server-only";          // Build error if imported client-side
+import { cache } from "react"; // Per-request memoization for Server Components
 
-export async function getSession() {
-  const cookieStore = await cookies();
-  const token = cookieStore.get(COOKIE_NAMES.SESSION);
-  // Validate with backend...
-}
-<% } %>
+export const getSession = cache(async () => {
+  const response = await fetch(`${AUTH_CONFIG.backendUrl}/api/auth/get-session`, {
+    headers: await buildAuthHeaders(),
+    cache: "no-store",          // opt out of the data cache
+  });
+  // ...validate response, return AuthSession | null
+});
 ```
+
+`cache: "no-store"` only opts out of the data cache — it does **not** dedupe within a request. `React.cache()` is what guarantees layout + page share one call.
+
+Keep this file out of `'use server'`: every export of a Server Action file becomes a callable action over RPC, which would defeat per-request memoization. Put sign-in / sign-out / form actions in a separate `actions.ts` file.
+<% } %>
 
 ### Client-Safe Code
 
@@ -169,6 +176,20 @@ export async function generateCodeChallenge(verifier: string): Promise<string> {
 }
 ```
 <% } %>
+
+### Why split `actions.ts` and `session.ts`?
+
+`actions.ts` is `'use server'`. Every export becomes a callable Server Action — Next.js generates an RPC ID for it and exposes it to client components. That is the right model for sign-in, sign-out, form submissions, and any mutation triggered from the UI.
+
+It is the wrong model for `getSession()`. We want one shared backend round-trip per request when a layout and its nested pages all read the session. React's `cache()` provides that — it memoizes by arguments within a single render pass. But `cache()` only works on plain Server Component code; wrapping it in `'use server'` turns every call into a fresh RPC and defeats the memoization.
+
+So:
+
+- `actions.ts` (`'use server'`) — `signIn`, `signOut`, `loginAction`, form actions, mutations
+- `session.ts` (`import "server-only"`, `cache()`-wrapped) — `getSession` and any other request-scoped read
+- `sessions.ts` — list / revoke sessions (also `'use server'` since these are mutations called from buttons)
+
+When a Server Action inside `actions.ts` needs the current session (e.g. an admin check inside `loginAction`), it imports `getSession` from `./session` — no cycle because `cache()` is invoked at request time, not module load.
 <% } %>
 
 ## Best Practices

--- a/templates/services/base/web/src/lib/auth/actions.ts.ejs
+++ b/templates/services/base/web/src/lib/auth/actions.ts.ejs
@@ -12,6 +12,7 @@ import {
   clearTwoFactorCookie,
 <% } %>
 } from './cookies';
+import { getSession } from './session';
 import { AUTH_CONFIG, BETTER_AUTH_COOKIE_NAME<% if (features.authentication.twoFactor) { %>, BETTER_AUTH_TWO_FACTOR_COOKIE_NAME, COOKIE_NAMES<% } %> } from './config';
 
 // Types
@@ -271,42 +272,6 @@ export async function signOut(): Promise<{ success: boolean }> {
   await clearSessionCookie();
 
   return { success: true };
-}
-
-/**
- * Get current session (validates with backend)
- *
- * Note: For client-side caching, use the AuthProvider which
- * maintains a cache to avoid hitting the backend on every render.
- */
-export async function getSession(): Promise<AuthSession | null> {
-  const sessionToken = await getSessionToken();
-
-  if (!sessionToken) {
-    return null;
-  }
-
-  try {
-    const response = await fetch(`${AUTH_CONFIG.backendUrl}/api/auth/get-session`, {
-      method: 'GET',
-      headers: await buildAuthHeaders(),
-      cache: 'no-store',
-    });
-
-    if (!response.ok) {
-      // Don't try to clear cookie here - it doesn't work in Server Components
-      // Server Components can't send Set-Cookie headers when using redirect()
-      // The protected layout redirects to /auth/session-expired which is a
-      // Route Handler that properly clears the cookie
-      return null;
-    }
-
-    const data = await response.json();
-    return data as AuthSession;
-  } catch (error) {
-    console.error('Get session error:', error);
-    return null;
-  }
 }
 
 /**

--- a/templates/services/base/web/src/lib/auth/session.ts.ejs
+++ b/templates/services/base/web/src/lib/auth/session.ts.ejs
@@ -1,0 +1,41 @@
+import 'server-only';
+import { cache } from 'react';
+import { getSessionToken } from './cookies';
+import { buildAuthHeaders } from './actions';
+import type { AuthSession } from './actions';
+import { AUTH_CONFIG } from './config';
+
+// Wrapped in React.cache() so a layout + its nested pages share one backend
+// call per request. `cache: 'no-store'` alone only opts out of the data cache;
+// it does NOT dedupe within a request. Keep this file out of 'use server' —
+// every export in a Server Action file becomes a callable action, which would
+// defeat the per-request memoization.
+export const getSession = cache(async (): Promise<AuthSession | null> => {
+  const sessionToken = await getSessionToken();
+
+  if (!sessionToken) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${AUTH_CONFIG.backendUrl}/api/auth/get-session`, {
+      method: 'GET',
+      headers: await buildAuthHeaders(),
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      // Don't try to clear cookie here - it doesn't work in Server Components.
+      // Server Components can't send Set-Cookie headers when using redirect().
+      // The protected layout redirects to /auth/session-expired which is a
+      // Route Handler that properly clears the cookie.
+      return null;
+    }
+
+    const data = await response.json();
+    return data as AuthSession;
+  } catch (error) {
+    console.error('Get session error:', error);
+    return null;
+  }
+});

--- a/templates/services/base/web/src/store/BEST_PRACTICES.md
+++ b/templates/services/base/web/src/store/BEST_PRACTICES.md
@@ -9,7 +9,7 @@ Zustand stores are for **client-side global state** that needs to persist across
 - UI state (modals, toasts, sidebar)
 - Client-side caches that don't map to a server resource
 
-For server data and mutations, prefer **server actions with `revalidatePath`/`revalidateTag`**, `useActionState`, and `useFormStatus` instead.
+For server data and mutations, prefer **server actions with `updateTag(tag)`** (read-your-own-writes, immediate refresh in the same request — the idiomatic Next 16 call), or `revalidateTag(tag)` / `revalidatePath(path)` for background invalidation, plus `useActionState` and `useFormStatus` for form state. Avoid `revalidateTag(tag, 'max')` — with `cacheLife('max')` the path is not marked revalidated, so the current request keeps serving stale data; use `updateTag(tag)` instead.
 
 ## Store Structure Pattern
 


### PR DESCRIPTION
## Summary

Two correctness bugs surfaced by a code review of a real stackr-generated project, both rooted in pre-Next-16 caching idioms baked into the web templates and their architecture docs. Templates today predate Next 16 and don't teach `updateTag` / `React.cache()`, so generated projects inherit the wrong defaults.

- **`revalidateTag` → `updateTag` for mutating admin actions.** `revalidateTag(tag)` (especially with a `cacheLife` profile like `'max'`) is treated as stale-while-revalidate in Next 16 — the path is NOT marked revalidated and the current request keeps serving stale data. `updateTag(tag)` is the explicit read-your-own-writes primitive. Verified against the [`use cache` directive docs](https://nextjs.org/docs/app/api-reference/directives/use-cache). Swap applied at `templates/services/auth/web/src/lib/admin/actions.ts` (`updateUserRole`, `deleteUser`).
- **`getSession()` deduped via `React.cache()`.** It used to live in `'use server'` `actions.ts` with `fetch(..., cache: 'no-store')` and no wrapper, so layout + nested pages each hit the auth backend per render. `no-store` opts out of the data cache, not request memoization — those are separate ([Vercel React `server-cache-react` rule](https://react.dev/reference/react/cache)). Moved to a new `lib/auth/session.ts` (singular — distinct from existing `sessions.ts` list/revoke) with `cache()` + `import "server-only"`. Kept out of `'use server'` because every export of an action file becomes a callable RPC, which would defeat the memoization. Importers updated in `templates/services/auth/web/` and `templates/features/web/auth/`.

## Docs refreshed

- `templates/services/base/web/DESIGN.md.ejs` — session-management section explains the `cache()` dedup; state-management philosophy distinguishes `updateTag` (immediate, idiomatic Next 16) vs `revalidateTag` (background), with an explicit warning against `revalidateTag(tag, 'max')`.
- `templates/services/base/web/src/lib/BEST_PRACTICES.md.ejs` — directory listing gains `session.ts`; server-only example shows the `cache()` pattern; new "Why split `actions.ts` and `session.ts`?" subsection explains the `'use server'` constraint.
- `templates/services/base/web/src/store/BEST_PRACTICES.md` — Zustand-vs-server-actions guidance updated.

## Scope

- **Templates only** — CLI generator code is unchanged; templates are static EJS so no Plop/Hygen wiring to touch.
- **14 files**: 2 new (`session.ts`, `session.ts.ejs`), 12 modified (4 protected-route templates, 2 action files, 1 admin action, 1 dashboard layout, 1 user detail page, 3 docs).
- **No tests broken** — nothing in the suite asserts on the old `revalidateTag` string or the action file's `getSession` location.

## Test plan

- [x] `bun run test` — 571/571 across 69 files
- [x] Verified no leftover `getSession.*from.*actions` imports across templates
- [x] Verified `revalidateTag` references in templates remain only in docs (intentional — they explain the contrast with `updateTag`)
- [x] EJS conditional balance checked for `BEST_PRACTICES.md.ejs` (auth.enabled + hasOAuth nested branches)
- [x] Manual smoke: generate a fresh project, navigate `/dashboard` (admin), edit a user — list reflects change without hard refresh (`updateTag` semantics)
- [x] Manual smoke: log `getSession`, hit `/dashboard/users/[id]` (calls in both layout AND page), confirm one backend fetch per request (`React.cache()` dedup)

Closes #78.