### PR TITLE
fix(tests): skip git init in test runs to remove ENOTEMPTY flake

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,9 +1,18 @@
 import { execa } from 'execa';
 
 /**
- * Initialize a git repository with an initial commit
+ * Initialize a git repository with an initial commit.
+ *
+ * No-op when `STACKR_SKIP_GIT_INIT` is set. The test harness flips this in
+ * `tests/utils/setup.ts` so integration tests don't pay the cost of
+ * `git init` + `git add .` + `git commit` (≈100 ms each) and don't race
+ * with git's async background writes (gc / fsmonitor / pack writes) during
+ * `fs.remove(tempDir)` cleanup — the source of the ENOTEMPTY flake on
+ * `.git/objects/` we hit on Linux CI.
  */
 export async function initializeGit(targetDir: string): Promise<void> {
+  if (process.env.STACKR_SKIP_GIT_INIT) return;
+
   // Check if git is available
   try {
     await execa('git', ['--version']);

--- a/tests/utils/setup.ts
+++ b/tests/utils/setup.ts
@@ -11,6 +11,12 @@
 // Set test environment variables
 process.env.NODE_ENV = 'test';
 
+// Skip `git init` + `git add` + `git commit` inside `MonorepoGenerator`.
+// Background git activity (gc / pack writes / fsmonitor) races with
+// per-test `fs.remove(tempDir)` cleanup on Linux CI and produces flaky
+// ENOTEMPTY failures on `.git/objects/`. See src/utils/git.ts.
+process.env.STACKR_SKIP_GIT_INIT = '1';
+
 // Increase timeout for slow operations
 import { beforeAll } from 'vitest';
 beforeAll(() => {


### PR DESCRIPTION
## Summary

Integration test suite hit an `ENOTEMPTY` flake on Linux CI:

```
FAIL  tests/integration/project-generator-queue-tests.test.ts > MonorepoGenerator — queue tests gating > auth/backend with eventQueue: false omits queue tests + bullmq helper
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/stackr-queue-tests-4QWLWX/test-minimal/.git/objects'
```

Root cause: `MonorepoGenerator.generate()` runs `initializeGit(targetDir)` at the end, spawning `git init` + `git add .` + `git commit` against the freshly-scaffolded project. On Linux CI git can leave background work in flight (gc / fsmonitor / pack writes); when the test's `afterEach` runs `await fs.remove(tempDir)`, the recursive removal races with a late-arriving write to `.git/objects/`.

This was a class-of-flake, not a one-off — 30+ integration tests call `generate()` then `fs.remove(tempDir)`. The queue-tests file just happened to lose the race this run.

## Fix

Gate `initializeGit` on a new `STACKR_SKIP_GIT_INIT` env var. Set it in `tests/utils/setup.ts` so every test file inherits the skip automatically. Production CLI behaviour is untouched — real users running `bun create stackr` don't have the var set, so git init runs as before.

Side benefit: dropping `git init` + `git add .` + `git commit` from every integration test cut the local integration suite wall time from ~28 s to ~10 s.

## Scope

- 2 files modified: `src/utils/git.ts` (early return on env var) + `tests/utils/setup.ts` (set the env var)
- 0 new deps
- No changes to test assertions — the test that flaked still passes its own assertions, just doesn't pay the git-init cost or hit the cleanup race

## Test plan

- [x] `bun run test:integration` × 3 consecutive runs — 42 files / 236 tests / all green, wall-clock ~10 s each (down from ~28 s flaky)
- [x] `bun run test` — full suite (unit + integration + e2e): 71 files / 576 tests / all green at 12.85 s wall-clock (down from ~40 s)
- [x] Verified no tests depend on `.git/` actually existing — only references in the test tree are a string match on `"git init"` in a recovery message (`tests/unit/errors.test.ts:101`) and a code comment in `tests/integration/config-conflicts.test.ts:39`
- [x] Production safety: `STACKR_SKIP_GIT_INIT` is unset in regular shells, so `bun create stackr` still initializes git on real runs. The env var is only set inside the vitest worker process and doesn't cross process boundaries.

Closes #83.
