### PR TITLE
chore(ci): bump Node 20→22 in publish workflow + engines.node

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "homepage": "https://github.com/itharea/create-stackr#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "bun@1.3.3",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Unblock the v0.6.1 publish. The tag was pushed but `publish.yml` exited 1 in `Run integration tests` ([run 26418680911](https://github.com/itharea/create-stackr/actions/runs/26418680911)).

### Root cause

```
TypeError: Object.groupBy is not a function
 ❯ validateDuplicateProductions node_modules/chevrotain/src/parse/grammar/checks.ts:105:35
 ❯ PrismaParser.performSelfAnalysis ...
```

`Object.groupBy` landed in Node 21. The publish workflow pinned `node-version: '20'`. The chevrotain grammar parser — transitive via `@mrleebo/prisma-ast`, introduced in #81's AST-based merge — calls it from a module-level `performSelfAnalysis()`, so 19 integration suites collected 0 tests because the import itself crashed.

`test.yml` was not affected: it only sets up Bun, and `bun run vitest` executes vitest under Bun's runtime (which has `Object.groupBy`). `publish.yml` adds `actions/setup-node@v4`, which puts node on PATH and vitest's `#!/usr/bin/env node` shebang resolves to it.

### Changes

- **`.github/workflows/publish.yml`** — `node-version: '20'` → `'22'`. Node 22 is current LTS and has `Object.groupBy`.
- **`package.json`** — `engines.node` `>=18.0.0` → `>=22.0.0`. End users on Node 18/20 will hit the same crash when they run `stackr add service` against a Prisma project; the engines bump surfaces it as an npm install-time warning instead of a cryptic runtime error.

### Follow-up (not in this PR)

`test.yml` doesn't pin node either, so it relies on whatever ubuntu-latest happens to preinstall. The e2e job spawns `node bin/stackr.js`. Worth pinning Node 22 there too as a defensive change, but out of scope for unblocking the v0.6.1 publish.

## Test plan

- [x] CI green on this PR
- [x] After merge, delete and re-push `v0.6.1` tag → `publish.yml` reruns on Node 22 → `npm publish create-stackr@0.6.1 --provenance` succeeds
- [ ] GitHub Release `v0.6.1` created