### PR TITLE
chore(ci): migrate publish to npm trusted publishing (OIDC) + bump to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -45,8 +45,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Extract version from tag
         id: version


### PR DESCRIPTION
## Summary

Replace the long-lived `NPM_TOKEN` secret with npm's OIDC-based **trusted publishing**. The same GitHub Actions OIDC identity that already signs provenance statements now authenticates the publish upload itself — no token to rotate, no secret to leak.

### Why now

The v0.6.1 publish in [run 26419008290](https://github.com/itharea/create-stackr/actions/runs/26419008290) failed with `E404 PUT https://registry.npmjs.org/create-stackr` because `NPM_TOKEN` had silently expired since v0.6.0 shipped on 2026-05-12 (npm automation tokens have configurable expiry). Trusted publishing eliminates that whole class of failure: each job mints a fresh ~10-minute OIDC token; the registry verifies GitHub-signed claims (repo, workflow filename, ref) against the Trusted Publisher configured on npmjs.com.

### Changes

- **`Setup Node.js`** — bump `node-version` 22 → 24 (current LTS, bundles npm 11.5+ which has trusted-publishing support out of the box). `engines.node` stays at `>=22.0.0` — CI validates forward, engines tracks the minimum we actually support.
- **`Publish to npm`** — drop the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env block. `id-token: write` is already in `permissions:` so the npm CLI can request and use the OIDC token automatically.

### Prerequisite (configured separately on npmjs.com, not in this PR)

At https://www.npmjs.com/package/create-stackr/access → Trusted Publisher:

| Field | Value |
|---|---|
| Publisher | GitHub Actions |
| Repository | `itharea/create-stackr` |
| Workflow filename | `publish.yml` |
| Environment | *(none)* |

### After merge

- Retag `v0.6.1` to trigger a fresh publish under the new auth model.
- Delete the `NPM_TOKEN` secret from GitHub repo settings once the publish succeeds.

## Test plan

- [x] Trusted Publisher configured on npmjs.com before tag push
- [ ] Re-pushed `v0.6.1` tag triggers `publish.yml`, OIDC handshake succeeds, `npm publish` returns 2xx
- [ ] GitHub Release `v0.6.1` created
- [x] `NPM_TOKEN` secret deleted from repo settings