### PR TITLE
feat(cli,templates): fixed auth ports (8888/3333) + contiguous base port allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cd my-app
 npm run setup && npm run docker:dev
 ```
 
-That's it. The project boots on `http://localhost:8080` (auth) and `http://localhost:8081` (core service).
+That's it. The project boots with the auth service on `http://localhost:8888` and the core service on `http://localhost:8080`.
 
 ## Requirements
 

--- a/docs/app/docs/architecture/frontends/page.mdx
+++ b/docs/app/docs/architecture/frontends/page.mdx
@@ -42,7 +42,7 @@ Each web frontend is a Next.js App Router app styled with **Tailwind CSS** and
 ## The admin dashboard
 
 When you enable the auth service's dashboard (on by default), stackr generates a
-full Next.js admin app on port **`:3002`** — login, a user list, role management, and
+full Next.js admin app on port **`:3333`** — login, a user list, role management, and
 user deletion — wired to the auth service. It's a working surface for managing your
 users on day one, and a reference for how a stackr web app consumes the auth backend.
 

--- a/docs/app/docs/architecture/infrastructure/page.mdx
+++ b/docs/app/docs/architecture/infrastructure/page.mdx
@@ -43,9 +43,9 @@ Ports are allocated deterministically so committed scripts and CI stay reproduci
 <Table
     headers={['Port', 'Assignment']}
     rows={[
-        ['8082 / 3002', 'Auth backend / admin dashboard (fixed)'],
-        ['8080, 8081, …', 'Base backends (skip 8082)'],
-        ['3000, 3001, …', 'Base web frontends (skip 3002)'],
+        ['8888 / 3333', 'Auth backend / admin dashboard (fixed)'],
+        ['8080, 8081, 8082, …', 'Base backends (contiguous)'],
+        ['3000, 3001, 3002, …', 'Base web frontends (contiguous)'],
         ['+10000', 'Test profile offset (db 15432+, redis 16379+, app 18080+)'],
     ]}
 />

--- a/docs/app/docs/architecture/services/page.mdx
+++ b/docs/app/docs/architecture/services/page.mdx
@@ -27,7 +27,7 @@ Every other service treats it as the source of truth for "who is this request?".
     (<code>no-auth-tables-outside-auth</code>) and a Prisma-side check.
 </Callout>
 
-It also ships an optional **admin dashboard** (Next.js) on port `:3002` for managing
+It also ships an optional **admin dashboard** (Next.js) on port `:3333` for managing
 users and roles — see [Frontends](/docs/architecture/frontends).
 
 ## Base services

--- a/docs/app/docs/configuration/page.mdx
+++ b/docs/app/docs/configuration/page.mdx
@@ -91,7 +91,7 @@ with **strong random credentials** — a 24-character database password and a
     code={`# Generated, never committed
 POSTGRES_PASSWORD=<24-char random>
 BETTER_AUTH_SECRET=<64 hex chars>
-AUTH_SERVICE_URL=http://auth:8082`}
+AUTH_SERVICE_URL=http://auth:8888`}
     language="bash"
     filename=".env"
 />
@@ -112,10 +112,10 @@ are reproducible:
 <Table
     headers={['Port', 'Assignment']}
     rows={[
-        ['8082', 'Auth backend (fixed)'],
-        ['3002', 'Auth admin dashboard (fixed)'],
-        ['8080, 8081, …', 'Base service backends (skip 8082)'],
-        ['3000, 3001, …', 'Base service web frontends (skip 3002)'],
+        ['8888', 'Auth backend (fixed)'],
+        ['3333', 'Auth admin dashboard (fixed)'],
+        ['8080, 8081, 8082, …', 'Base service backends (contiguous)'],
+        ['3000, 3001, 3002, …', 'Base service web frontends (contiguous)'],
         ['+10000 offset', 'Test profile (e.g. db 15432, redis 16379, app 18080)'],
     ]}
 />

--- a/docs/app/docs/development/page.mdx
+++ b/docs/app/docs/development/page.mdx
@@ -17,7 +17,7 @@ npm run docker:dev  # bring all services + their DBs and Redis up`}
     language="bash"
 />
 
-With the default config, `auth` is on `:8082` (admin dashboard `:3002`) and `core` on
+With the default config, `auth` is on `:8888` (admin dashboard `:3333`) and `core` on
 `:8080`.
 
 ## Run a single service

--- a/docs/app/docs/features/authentication/page.mdx
+++ b/docs/app/docs/features/authentication/page.mdx
@@ -58,7 +58,7 @@ device-session token instead.
 ## The admin dashboard
 
 With the dashboard enabled, the auth service ships a Next.js admin app on port
-**`:3002`** — sign in, list users, manage roles, and delete users out of the box. It
+**`:3333`** — sign in, list users, manage roles, and delete users out of the box. It
 doubles as a reference implementation for consuming the auth backend from a stackr web
 app.
 

--- a/docs/app/docs/quick-start/page.mdx
+++ b/docs/app/docs/quick-start/page.mdx
@@ -74,13 +74,13 @@ selections above you get:
 <Table
     headers={['Service', 'Backend', 'Web']}
     rows={[
-        ['auth (trust anchor)', 'http://localhost:8082', 'http://localhost:3002 (admin dashboard)'],
+        ['auth (trust anchor)', 'http://localhost:8888', 'http://localhost:3333 (admin dashboard)'],
         ['core (base service)', 'http://localhost:8080', 'http://localhost:3000'],
     ]}
 />
 
 <Callout type="info" title="Port convention">
-    The auth backend is fixed at <code>:8082</code> and its dashboard at <code>:3002</code>.
+    The auth backend is fixed at <code>:8888</code> and its dashboard at <code>:3333</code>.
     Base services start at <code>:8080</code> (backends) and <code>:3000</code> (web). See
     <a href="/docs/configuration#ports">Configuration → Ports</a>.
 </Callout>

--- a/docs/app/docs/troubleshooting/page.mdx
+++ b/docs/app/docs/troubleshooting/page.mdx
@@ -24,7 +24,7 @@ This is intentional — it stops the config and the database from drifting apart
 
 ## Port already in use
 
-Services use deterministic ports: auth `:8082` / `:3002`, base backends from `:8080`, base
+Services use deterministic ports: auth `:8888` / `:3333`, base backends from `:8080`, base
 web from `:3000`. If another process holds one, stop it, or pass an explicit `--port` when
 adding a service. The test profiles use a `+10000` offset so they never collide with a dev
 stack.
@@ -54,7 +54,7 @@ routes 401:
 
 <CodeBlock
     code={`# from the base service container, the auth check is essentially:
-curl -i http://auth:8082/api/auth/get-session -H "cookie: <session cookie>"`}
+curl -i http://auth:8888/api/auth/get-session -H "cookie: <session cookie>"`}
     language="bash"
 />
 
@@ -69,7 +69,7 @@ directory — each service has its own database and its own migration history. T
 Usually a redirect-URI mismatch or CORS. Check that the redirect URI exactly matches the
 provider config, that the auth service's CORS allows your web origin, and that
 third-party cookies aren't blocked in dev. **Apple Sign-In requires HTTPS** and won't work
-on `http://localhost` — use a tunnel (e.g. `ngrok http 8082`) or test it on a staging host.
+on `http://localhost` — use a tunnel (e.g. `ngrok http 8888`) or test it on a staging host.
 
 ## Mobile: Metro bundler is stuck
 

--- a/docs/components/ui/CrossServiceAuthVisual.tsx
+++ b/docs/components/ui/CrossServiceAuthVisual.tsx
@@ -27,7 +27,7 @@ const steps: Step[] = [
     },
     {
         icon: ShieldCheck,
-        title: 'auth :8082 · /api/auth/get-session',
+        title: 'auth :8888 · /api/auth/get-session',
         detail: 'The trust anchor validates the session and returns the principal.',
         edge: '← { user, session }',
         accent: true,

--- a/docs/components/ui/ServiceIsolationVisual.tsx
+++ b/docs/components/ui/ServiceIsolationVisual.tsx
@@ -20,8 +20,8 @@ const services: ServiceCard[] = [
     {
         name: 'auth',
         role: 'trust anchor',
-        backendPort: ':8082',
-        webPort: ':3002',
+        backendPort: ':8888',
+        webPort: ':3333',
         trustAnchor: true,
         resources: [
             { label: 'Fastify · BetterAuth', icon: ShieldCheck },
@@ -39,7 +39,7 @@ const services: ServiceCard[] = [
             { label: 'PostgreSQL', icon: Database },
             { label: 'Redis', icon: Server },
         ],
-        footer: { label: 'verifies via auth:8082', icon: Lock },
+        footer: { label: 'verifies via auth:8888', icon: Lock },
     },
     {
         name: 'wallet',
@@ -50,7 +50,7 @@ const services: ServiceCard[] = [
             { label: 'PostgreSQL', icon: Database },
             { label: 'BullMQ + Redis', icon: MessageSquare },
         ],
-        footer: { label: 'verifies via auth:8082', icon: Lock },
+        footer: { label: 'verifies via auth:8888', icon: Lock },
     },
 ];
 

--- a/src/utils/port-allocator.ts
+++ b/src/utils/port-allocator.ts
@@ -3,11 +3,17 @@ import type { ServiceConfig } from '../types/index.js';
 /**
  * Port allocation for services.
  *
- * Convention (see `plans/meta_phases.md` §1 decision #5):
- * - Auth backend is fixed at 8082.
- * - Base service backends start at 8080, increment by 1, skipping 8082.
- * - Base service web frontends start at 3000, increment by 1, skipping 3002.
- * - Auth web admin dashboard is fixed at 3002.
+ * Convention:
+ * - Auth backend is fixed at 8888.
+ * - Auth web admin dashboard is fixed at 3333.
+ * - Base service backends start at 8080 and increment by 1 (contiguous).
+ * - Base service web frontends start at 3000 and increment by 1 (contiguous).
+ *
+ * There is always exactly one auth service but a variable number of base
+ * services, so the auth ports sit well above the base ranges rather than
+ * inside them. Base allocation never walks far enough to reach 8888/3333,
+ * and the auth service is in the `taken` set at allocation time anyway, so
+ * the contiguous walk can't collide with it.
  *
  * `allocateBackendPort(services, preferred?)` returns the next free backend
  * port NOT already taken by a service in `services`. If `preferred` is
@@ -18,8 +24,8 @@ import type { ServiceConfig } from '../types/index.js';
  * why they're standalone rather than inlined into the generator.
  */
 
-const RESERVED_AUTH_BACKEND_PORT = 8082;
-const RESERVED_AUTH_WEB_PORT = 3002;
+export const AUTH_BACKEND_PORT = 8888;
+export const AUTH_WEB_PORT = 3333;
 const BASE_BACKEND_START = 8080;
 const BASE_WEB_START = 3000;
 
@@ -54,10 +60,10 @@ function collectWebPorts(services: readonly ServiceConfig[]): Set<number> {
  * Pick the next free backend port for a new base service.
  *
  * - If `preferred` is supplied, it must be free (not already used by an
- *   existing entry in `services`). `preferred` may equal 8082 — the caller
- *   is trusted to pass that only when allocating for the auth service.
- * - Otherwise, walk from 8080 upward, skipping any port already used or
- *   the auth-reserved 8082.
+ *   existing entry in `services`). The caller may pass the auth port (8888)
+ *   only when allocating for the auth service itself.
+ * - Otherwise, walk contiguously from 8080 upward, returning the first port
+ *   not already used by a service in `services`.
  */
 export function allocateBackendPort(
   services: readonly ServiceConfig[],
@@ -74,10 +80,6 @@ export function allocateBackendPort(
 
   let candidate = BASE_BACKEND_START;
   while (true) {
-    if (candidate === RESERVED_AUTH_BACKEND_PORT) {
-      candidate++;
-      continue;
-    }
     if (!taken.has(candidate)) {
       return candidate;
     }
@@ -89,7 +91,7 @@ export function allocateBackendPort(
 }
 
 /**
- * Pick the next free web port. Reserves 3002 for the auth admin dashboard.
+ * Pick the next free web port, walking contiguously from 3000 upward.
  */
 export function allocateWebPort(
   services: readonly ServiceConfig[],
@@ -106,10 +108,6 @@ export function allocateWebPort(
 
   let candidate = BASE_WEB_START;
   while (true) {
-    if (candidate === RESERVED_AUTH_WEB_PORT) {
-      candidate++;
-      continue;
-    }
     if (!taken.has(candidate)) {
       return candidate;
     }
@@ -120,17 +118,15 @@ export function allocateWebPort(
   }
 }
 
-export const AUTH_BACKEND_PORT = RESERVED_AUTH_BACKEND_PORT;
-export const AUTH_WEB_PORT = RESERVED_AUTH_WEB_PORT;
-
 /*
  * +10000 offset applied uniformly to DB, Redis, and app ports in the
  * unified test compose. Leaves headroom for ~1000 services before
  * crossing into ephemeral-port space (linux default `ip_local_port_range`
  * starts at 32768). No collision with dev compose: dev DB host ports are
  * `5432, 5433, …`, dev Redis host ports are `6379, 6380, …`, dev app
- * ports are `8080, 8082, 8081, …` — test equivalents are `15432+`,
- * `16379+`, and `18080+`, disjoint on every axis. If you relocate this
+ * ports are `8080, 8081, 8082, …` (base) plus `8888` (auth) — test
+ * equivalents are `15432+`, `16379+`, and `18080+` / `18888`, disjoint on
+ * every axis. If you relocate this
  * offset, existing generated projects' `.env.test` and
  * `docker-compose.test.yml` both hard-code it.
  */

--- a/templates/features/mobile/auth/hooks/auth.ts.ejs
+++ b/templates/features/mobile/auth/hooks/auth.ts.ejs
@@ -17,7 +17,7 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 <% } %>
 
 // Auth service URL — custom auth endpoints (profile, account, 2FA) live on the auth service
-const API_URL = Constants.expoConfig?.extra?.authServiceUrl || 'http://localhost:<%= authServicePort || 8082 %>';
+const API_URL = Constants.expoConfig?.extra?.authServiceUrl || 'http://localhost:<%= authServicePort || 8888 %>';
 
 /**
  * Auth hook using BetterAuth's useSession() directly

--- a/templates/services/auth/backend/controllers/rest-api/index.ts
+++ b/templates/services/auth/backend/controllers/rest-api/index.ts
@@ -4,7 +4,7 @@ const start = async () => {
   const server = await buildServer();
   try {
     const host = server.config.API_HOST || '0.0.0.0';
-    const port = parseInt(server.config.API_PORT || '8080');
+    const port = parseInt(server.config.API_PORT || '8888');
 
     await server.listen({
       host,

--- a/templates/services/auth/backend/controllers/rest-api/plugins/config.ts
+++ b/templates/services/auth/backend/controllers/rest-api/plugins/config.ts
@@ -36,7 +36,7 @@ const configPlugin: FastifyPluginAsync = async (server) => {
     NODE_ENV: process.env.NODE_ENV || 'development',
     LOG_LEVEL: process.env.LOG_LEVEL || 'info',
     API_HOST: process.env.API_HOST || '0.0.0.0',
-    API_PORT: process.env.API_PORT || '8080',
+    API_PORT: process.env.API_PORT || '8888',
     DATABASE_URL: process.env.DATABASE_URL,
     JWT_SECRET: process.env.JWT_SECRET || 'your-jwt-secret-here-change-in-production',
     ...process.env,

--- a/templates/services/base/backend/.env.example.ejs
+++ b/templates/services/base/backend/.env.example.ejs
@@ -25,7 +25,7 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/<%= projectName.toLo
 # the full stack via docker-compose this is wired automatically to the
 # internal container DNS name; for local-dev-without-docker set it to the
 # host-mapped auth port.
-AUTH_SERVICE_URL=http://localhost:<%= authServicePort || 8082 %>
+AUTH_SERVICE_URL=http://localhost:<%= authServicePort || 8888 %>
 
 <% } -%>
 # Redis Configuration

--- a/templates/services/base/backend/controllers/rest-api/plugins/auth.ts.ejs
+++ b/templates/services/base/backend/controllers/rest-api/plugins/auth.ts.ejs
@@ -24,7 +24,7 @@ import { updateDeviceSessionActivity } from "../../../domain/device-session/repo
 import { DeviceSession } from "../../../domain/device-session/schema";
 import { ErrorFactory, normalizeError } from "../../../utils/errors";
 
-const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:<%= authServicePort || 8082 %>';
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:<%= authServicePort || 8888 %>';
 
 interface AuthUser {
   id: string;
@@ -223,7 +223,7 @@ import fp from "fastify-plugin";
 import { FastifyPluginAsync, FastifyRequest, FastifyReply } from "fastify";
 import { ErrorFactory, normalizeError } from "../../../utils/errors";
 
-const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:<%= authServicePort || 8082 %>';
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:<%= authServicePort || 8888 %>';
 const ALLOWED_ROLES = [<%- rolesList.map((r) => `'${r}'`).join(', ') %>];
 
 interface AuthUser {
@@ -304,7 +304,7 @@ import fp from "fastify-plugin";
 import { FastifyPluginAsync, FastifyRequest, FastifyReply } from "fastify";
 import { ErrorFactory, normalizeError } from "../../../utils/errors";
 
-const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:<%= authServicePort || 8082 %>';
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:<%= authServicePort || 8888 %>';
 
 interface AuthUser {
   id: string;

--- a/templates/services/base/mobile/src/lib/auth-client.ts.ejs
+++ b/templates/services/base/mobile/src/lib/auth-client.ts.ejs
@@ -10,7 +10,7 @@ import * as SecureStore from "expo-secure-store";
 import Constants from "expo-constants";
 
 // Auth service URL — mobile talks directly to the central auth service
-const API_URL = Constants.expoConfig?.extra?.authServiceUrl || "http://localhost:<%= authServicePort || 8082 %>";
+const API_URL = Constants.expoConfig?.extra?.authServiceUrl || "http://localhost:<%= authServicePort || 8888 %>";
 
 // Get app scheme from Expo config (defined at expo.scheme in app.json)
 const APP_SCHEME = Constants.expoConfig?.scheme || "<%= appScheme %>";

--- a/tests/integration/add-service-port-collision.test.ts
+++ b/tests/integration/add-service-port-collision.test.ts
@@ -18,8 +18,8 @@ describe('stackr add service — port handling', () => {
     await runAddService('wallet', { install: false });
     const cfg = await loadStackrConfig(fx.projectDir);
     const wallet = cfg.services.find((s) => s.name === 'wallet');
-    // Minimal fixture uses auth@8082, core@8080. Next free backend port
-    // skipping 8082 is 8081.
+    // Minimal fixture uses auth@8888, core@8080. Next free contiguous
+    // backend port above core is 8081.
     expect(wallet?.backend.port).toBe(8081);
   });
 

--- a/tests/integration/project-generator-env-credentials.test.ts
+++ b/tests/integration/project-generator-env-credentials.test.ts
@@ -272,7 +272,7 @@ describe('MonorepoGenerator — init-time credential generation', () => {
     expect(await fs.pathExists(envLocalPath)).toBe(true);
     const content = await fs.readFile(envLocalPath, 'utf-8');
 
-    expect(content).toMatch(/^BACKEND_URL=http:\/\/localhost:8082$/m);
+    expect(content).toMatch(/^BACKEND_URL=http:\/\/localhost:8888$/m);
   });
 
   it('core/web/.env.local includes AUTH_SERVICE_URL pointing at auth backend', async () => {
@@ -280,7 +280,7 @@ describe('MonorepoGenerator — init-time credential generation', () => {
       path.join(projectDir, 'core/web/.env.local'),
       'utf-8'
     );
-    expect(content).toMatch(/^AUTH_SERVICE_URL=http:\/\/localhost:8082$/m);
+    expect(content).toMatch(/^AUTH_SERVICE_URL=http:\/\/localhost:8888$/m);
   });
 
   it('web .env.example files are left untouched (not overwritten by .env.local generation)', async () => {
@@ -332,7 +332,7 @@ describe('MonorepoGenerator — init-time credential generation', () => {
     const pkgJson = JSON.parse(
       await fs.readFile(path.join(projectDir, 'auth/web/package.json'), 'utf-8')
     );
-    expect(pkgJson.scripts.dev).toContain('--port 3002');
+    expect(pkgJson.scripts.dev).toContain('--port 3333');
     expect(pkgJson.dependencies).toHaveProperty('sonner');
     expect(pkgJson.dependencies).toHaveProperty('@radix-ui/react-dialog');
   });

--- a/tests/integration/project-generator-web.test.ts
+++ b/tests/integration/project-generator-web.test.ts
@@ -288,8 +288,8 @@ describe('project generator — auth/web subtree (admin dashboard)', () => {
     const raw = await fs.readFile(path.join(projectDir, 'auth/web/package.json'), 'utf-8');
     const pkg = JSON.parse(raw);
     expect(pkg.name).toBe('test-auth-web-auth-web');
-    // Auth web dev server runs on its reserved port (3002)
-    expect(pkg.scripts?.dev).toBe('next dev --port 3002');
+    // Auth web dev server runs on its fixed port (3333)
+    expect(pkg.scripts?.dev).toBe('next dev --port 3333');
     expect(pkg.dependencies?.next).toBeDefined();
     expect(pkg.dependencies?.react).toBeDefined();
     // Auth dashboard dependencies
@@ -393,6 +393,6 @@ describe('project generator — auth/web subtree (admin dashboard)', () => {
       'utf-8'
     );
     expect(nextConfig).toMatch(/\/api\/:path\*/);
-    expect(nextConfig).toMatch(/8082/);
+    expect(nextConfig).toMatch(/8888/);
   });
 });

--- a/tests/unit/docker-compose-test.test.ts
+++ b/tests/unit/docker-compose-test.test.ts
@@ -198,8 +198,8 @@ describe('renderDockerComposeTest', () => {
       const coreEnv = parsed.services.core_rest_api.environment;
       const envStr = typeof coreEnv === 'string' ? coreEnv : JSON.stringify(coreEnv);
       expect(envStr).toContain('AUTH_SERVICE_URL');
-      // Dev port for auth is 8082 (AUTH_BACKEND_PORT).
-      expect(envStr).toContain('http://auth_rest_api:8082');
+      // Dev port for auth is 8888 (AUTH_BACKEND_PORT).
+      expect(envStr).toContain('http://auth_rest_api:8888');
     });
 
     it('does NOT inject AUTH_SERVICE_URL on the auth service itself', () => {

--- a/tests/unit/port-allocator-test-ports.test.ts
+++ b/tests/unit/port-allocator-test-ports.test.ts
@@ -32,7 +32,7 @@ function makeCore(port = 8080): ServiceConfig {
 }
 
 describe('computeTestPorts', () => {
-  it('[authEntry] alone returns { auth: { dbPort: 15432, redisPort: 16379, appPort: 18082 } }', () => {
+  it('[authEntry] alone returns { auth: { dbPort: 15432, redisPort: 16379, appPort: 18888 } }', () => {
     const auth = makeAuth();
     const result = computeTestPorts([auth]);
     expect(result).toEqual({
@@ -42,7 +42,7 @@ describe('computeTestPorts', () => {
         appPort: AUTH_BACKEND_PORT + TEST_PORT_OFFSET,
       },
     });
-    expect(result.auth.appPort).toBe(18082);
+    expect(result.auth.appPort).toBe(18888);
   });
 
   it('[core, auth] preserves declaration order for DB/Redis walk', () => {
@@ -58,7 +58,7 @@ describe('computeTestPorts', () => {
     expect(result.auth).toEqual({
       dbPort: 15433,
       redisPort: 16380,
-      appPort: 18082,
+      appPort: 18888,
     });
   });
 
@@ -70,7 +70,7 @@ describe('computeTestPorts', () => {
     expect(result.auth).toEqual({
       dbPort: 15432,
       redisPort: 16379,
-      appPort: 18082,
+      appPort: 18888,
     });
     expect(result.core).toEqual({
       dbPort: 15433,

--- a/tests/unit/port-allocator.test.ts
+++ b/tests/unit/port-allocator.test.ts
@@ -23,18 +23,18 @@ describe('port-allocator', () => {
       expect(allocateBackendPort([])).toBe(8080);
     });
 
-    it('returns 8081 when only auth (8082) exists', () => {
-      expect(allocateBackendPort([svc('auth', 8082)])).toBe(8080);
+    it('returns 8080 when only the auth service (8888) exists', () => {
+      expect(allocateBackendPort([svc('auth', AUTH_BACKEND_PORT)])).toBe(8080);
     });
 
-    it('skips 8082 when auto-allocating around auth', () => {
-      const services = [svc('auth', 8082), svc('a', 8080), svc('b', 8081)];
-      expect(allocateBackendPort(services)).toBe(8083);
+    it('allocates contiguously around auth (8888 is out of the base range)', () => {
+      const services = [svc('auth', AUTH_BACKEND_PORT), svc('a', 8080), svc('b', 8081)];
+      expect(allocateBackendPort(services)).toBe(8082);
     });
 
-    it('returns the next free port after existing services', () => {
+    it('returns the next free port after existing services (8082 is no longer reserved)', () => {
       const services = [svc('a', 8080), svc('b', 8081)];
-      expect(allocateBackendPort(services)).toBe(8083); // skipping 8082
+      expect(allocateBackendPort(services)).toBe(8082);
     });
 
     it('honors an explicit preferred port', () => {
@@ -45,8 +45,8 @@ describe('port-allocator', () => {
       expect(() => allocateBackendPort([svc('a', 9090)], 9090)).toThrow(PortCollisionError);
     });
 
-    it('AUTH_BACKEND_PORT constant equals 8082', () => {
-      expect(AUTH_BACKEND_PORT).toBe(8082);
+    it('AUTH_BACKEND_PORT constant equals 8888', () => {
+      expect(AUTH_BACKEND_PORT).toBe(8888);
     });
   });
 
@@ -55,29 +55,29 @@ describe('port-allocator', () => {
       expect(allocateWebPort([])).toBe(3000);
     });
 
-    it('skips 3002 (reserved for auth web admin)', () => {
+    it('allocates web ports contiguously (3002 is no longer reserved)', () => {
       const services = [svc('a', 8080, 3000), svc('b', 8081, 3001)];
-      expect(allocateWebPort(services)).toBe(3003);
+      expect(allocateWebPort(services)).toBe(3002);
     });
 
-    it('AUTH_WEB_PORT constant equals 3002', () => {
-      expect(AUTH_WEB_PORT).toBe(3002);
+    it('AUTH_WEB_PORT constant equals 3333', () => {
+      expect(AUTH_WEB_PORT).toBe(3333);
     });
   });
 
   describe('determinism (phase 3)', () => {
     it('allocating a new port against the same config twice yields the same result', () => {
-      const services = [svc('auth', 8082), svc('core', 8080), svc('scout', 8081)];
+      const services = [svc('auth', AUTH_BACKEND_PORT), svc('core', 8080), svc('scout', 8081)];
       const first = allocateBackendPort(services);
       const second = allocateBackendPort(services);
       expect(first).toBe(second);
-      expect(first).toBe(8083);
+      expect(first).toBe(8082);
     });
 
     it('allocating after differently-ordered inputs yields the same next port', () => {
-      const servicesA = [svc('core', 8080), svc('auth', 8082), svc('scout', 8081)];
-      const servicesB = [svc('auth', 8082), svc('scout', 8081), svc('core', 8080)];
-      // Both fill 8080, 8081, 8082 — so the next free port is 8083 in both.
+      const servicesA = [svc('core', 8080), svc('auth', AUTH_BACKEND_PORT), svc('scout', 8081)];
+      const servicesB = [svc('auth', AUTH_BACKEND_PORT), svc('scout', 8081), svc('core', 8080)];
+      // Base fills 8080, 8081 (auth at 8888 is out of range) — next free is 8082 in both.
       expect(allocateBackendPort(servicesA)).toBe(allocateBackendPort(servicesB));
     });
 

--- a/tests/unit/prompts.test.ts
+++ b/tests/unit/prompts.test.ts
@@ -425,15 +425,15 @@ describe('promptServices', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildExtraServicesFromFlag', () => {
-  it('parses comma-separated names and allocates sequential ports skipping 8082', () => {
+  it('parses comma-separated names and allocates sequential contiguous ports', () => {
     const existing = [authEntry({ provisioningTargets: [] })];
     const out = buildExtraServicesFromFlag('scout, wallet, manage', existing, true);
 
     expect(out.map((s) => s.name)).toEqual(['scout', 'wallet', 'manage']);
     expect(out[0].backend.port).toBe(8080);
     expect(out[1].backend.port).toBe(8081);
-    // 8082 is the reserved auth port, so the 3rd service gets 8083.
-    expect(out[2].backend.port).toBe(8083);
+    // Auth sits at 8888 (out of the base range), so allocation is contiguous.
+    expect(out[2].backend.port).toBe(8082);
     for (const svc of out) {
       expect(svc.backend.authMiddleware).toBe('standard');
       expect(svc.web).toBeNull();

--- a/tests/unit/service-context.test.ts
+++ b/tests/unit/service-context.test.ts
@@ -11,8 +11,8 @@ describe('buildServiceContext', () => {
 
     expect(ctx.hasAuthService).toBe(true);
     expect(ctx.authServiceName).toBe('auth');
-    expect(ctx.authServicePort).toBe(8082);
-    expect(ctx.authServiceUrl).toBe('http://auth_rest_api:8082');
+    expect(ctx.authServicePort).toBe(8888);
+    expect(ctx.authServiceUrl).toBe('http://auth_rest_api:8888');
     expect(ctx.peerServiceNames).toContain('auth');
   });
 


### PR DESCRIPTION
Superseded — recreated cleanly against issue #97. Closing.