### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-06-11
+
+### Changed
+
+- **Auth service now uses fixed ports `8888` (backend) / `3333` (admin dashboard), and base services are allocated contiguously** from `8080` (backends) and `3000` (web). Previously auth sat at `8082` / `3002` in the middle of the base range, forcing allocation to skip those ports and leave gaps (`8080, 8081, 8083, …`); base services now map cleanly to `8080 + index` / `3000 + index`, and a third base service simply uses `8082` like any other. The auth backend's default `API_PORT` and the templates' auth-URL fallbacks were updated to match, and the docs site/README now describe the new scheme. Affects newly scaffolded projects only — existing projects keep their ports frozen in `stackr.config.json`. (#98)
+
 ## [0.7.0] - 2026-06-04
 
 ### ⚠ BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-stackr",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Scaffold production-ready multi-microservice monorepos with Fastify backends, BetterAuth, Docker, and more",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release **v0.7.1** — bumps `package.json` `0.7.0 → 0.7.1` and adds the CHANGELOG entry. No other files touched (per the release convention).

## Included since v0.7.0

- **feat(cli,templates): fixed auth ports (8888/3333) + contiguous base port allocation** (#98) — auth service moves to fixed `8888`/`3333`; base services allocate contiguously from `8080`/`3000` (no reserved-port gap). Newly scaffolded projects only.

## After merge

Tag `v0.7.1` on `main` (not on the branch commit) to trigger `publish.yml` → build, unit/integration/e2e tests, `npm publish --provenance` (OIDC), and the GitHub Release (auto-marked prerelease while pre-1.0):

```
git checkout main && git pull --ff-only
git tag v0.7.1 && git push origin v0.7.1
```